### PR TITLE
Git ignores refactoring in history

### DIFF
--- a/.git-ignore-revs
+++ b/.git-ignore-revs
@@ -1,0 +1,2 @@
+# Black formatting
+e16d3b2094455bae3fe9b601c6249c6a2977a4e3

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[blame]
+        ignoreRevsFile = .git-ignore-revs

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,3 +3,9 @@ The code follows code styling by [black](https://github.com/psf/black).
 
 To automate code formatting, [pre-commit](https://github.com/pre-commit/pre-commit) is used, to run code checks before commiting changes.
 If you have pre-commit installed from the requirements-dev.txt simple run ``pre-commit install`` to install the hooks for this repo.
+
+# Setup
+
+### git setup for ignoring refactoring commits
+Run `git config --local include.path ../.gitconfig` inside your clone of the repo. 
+Update git to `2.23` or higher to be able to use this feature.


### PR DESCRIPTION
Implements the remaining feature in #9 
> [OPTIONAL] add this commit to list of ignored commits for git blame as described here https://akrabat.com/ignoring-revisions-with-git-blame/ - I think this can be skipped because so far you are the main author of the library and git history is not that rich.