### PR TITLE
Deprecates python35 - it has reached EOL in Oct 2020

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,16 @@ setuptools.setup(
     license="MIT",
     python_requires=">=3.5",
     packages=setuptools.find_packages(
-        exclude=["test", "test.*", "test_lib", "test_lib.*",
-                 "examples", "examples.*",
-                 "docs", "docs.*"]
+        exclude=[
+            "test",
+            "test.*",
+            "test_lib",
+            "test_lib.*",
+            "examples",
+            "examples.*",
+            "docs",
+            "docs.*",
+        ]
     ),
     classifiers=[
         # How mature is this project? Common values are
@@ -32,7 +39,6 @@ setuptools.setup(
         #   4 - Beta
         #   5 - Production/Stable
         "Development Status :: 4 - Beta",
-
         # Indicate who your project is intended for
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
@@ -40,10 +46,8 @@ setuptools.setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         # Pick your license as you wish (should match "license" above)
         "License :: OSI Approved :: MIT License",
-
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
@@ -62,5 +66,5 @@ setuptools.setup(
         "GPUtil",
         "Pillow",
         "tensorboardX",
-    ]
+    ],
 )


### PR DESCRIPTION
Python3.5 is by now [deprecated](https://www.python.org/downloads/release/python-3510/) and it's a security risk to use it. Removing it's support will allow using some modern language features, like for example f-strings.

Formatting changes: done by black pre-commit hook.
