### PR TITLE
Py36 style

### DIFF
--- a/machin/auto/dataset.py
+++ b/machin/auto/dataset.py
@@ -82,7 +82,7 @@ class RLDataset(IterableDataset):
     """
 
     def __init__(self, **_kwargs):
-        super(RLDataset, self).__init__()
+        super().__init__()
 
     def __iter__(self) -> Iterable:
         return self

--- a/machin/auto/env/openai_gym.py
+++ b/machin/auto/env/openai_gym.py
@@ -66,7 +66,7 @@ class RLGymDiscActDataset(RLDataset):
         render_every_episode: int = 100,
         act_kwargs: Dict[str, Any] = None,
     ):
-        super(RLGymDiscActDataset, self).__init__()
+        super().__init__()
         self.frame = frame
         self.env = env
         self.render_every_episode = render_every_episode
@@ -173,7 +173,7 @@ class RLGymContActDataset(RLDataset):
         render_every_episode: int = 100,
         act_kwargs: Dict[str, Any] = None,
     ):
-        super(RLGymContActDataset, self).__init__()
+        super().__init__()
         self.frame = frame
         self.env = env
         self.render_every_episode = render_every_episode
@@ -297,8 +297,9 @@ def gym_env_dataset_creator(frame, env_config):
         )
 
 
-def launch_gym(config: Union[Dict[str, Any], Config],
-               pl_callbacks: List[Callback] = None):
+def launch_gym(
+    config: Union[Dict[str, Any], Config], pl_callbacks: List[Callback] = None
+):
     """
     Args:
         config: All configs needed to launch a gym environment and initialize

--- a/machin/auto/launcher.py
+++ b/machin/auto/launcher.py
@@ -22,7 +22,7 @@ class Launcher(pl.LightningModule):
             env_dataset_creator: A callable which accepts the algorithm frame
                 and env config dictionary, and outputs a environment dataset.
         """
-        super(Launcher, self).__init__()
+        super().__init__()
         self.config = config
         self.env_dataset_creator = env_dataset_creator
         self.frame = init_algorithm_from_config(config)
@@ -106,4 +106,6 @@ class Launcher(pl.LightningModule):
                     log_val[1](self, log_key, log_val[0])
                 else:
                     is_dist_initialized = dist.is_available() and dist.is_initialized()
-                    self.log(log_key, log_val, prog_bar=True, sync_dist=is_dist_initialized)
+                    self.log(
+                        log_key, log_val, prog_bar=True, sync_dist=is_dist_initialized
+                    )

--- a/machin/auto/pl_logger.py
+++ b/machin/auto/pl_logger.py
@@ -15,7 +15,7 @@ class LocalMediaLogger(LightningLoggerBase):
     """
 
     def __init__(self, image_dir: str, artifact_dir: str):
-        super(LocalMediaLogger, self).__init__()
+        super().__init__()
         self.image_dir = image_dir
         self.artifact_dir = artifact_dir
         self._counters = {}

--- a/machin/auto/pl_logger.py
+++ b/machin/auto/pl_logger.py
@@ -86,12 +86,10 @@ class LocalMediaLogger(LightningLoggerBase):
             self._counters[log_name] = 0
 
         if not isinstance(image, str):
-            log_path = log_name + "_{}.png".format(step or self._counters[log_name])
+            log_path = log_name + f"_{step or self._counters[log_name]}.png"
         else:
             extension = os.path.splitext(image)[1]
-            log_path = log_name + "_{}{}".format(
-                step or self._counters[log_name], extension
-            )
+            log_path = log_name + f"_{step or self._counters[log_name]}{extension}"
         self._counters[log_name] += 1
 
         path = os.path.join(self.image_dir, log_path)

--- a/machin/auto/pl_plugin.py
+++ b/machin/auto/pl_plugin.py
@@ -51,8 +51,8 @@ class DDPPlugin(DDP):
                 rank=int(global_rank),
                 world_size=int(world_size),
                 dist_backend=self.torch_distributed_backend,
-                dist_init_method="tcp://{}:{}".format(master_addr, master_port),
-                rpc_init_method="tcp://{}:{}".format(master_addr, int(master_port) + 1),
+                dist_init_method=f"tcp://{master_addr}:{master_port}",
+                rpc_init_method=f"tcp://{master_addr}:{int(master_port) + 1}",
             )
 
     def training_step(self, *args, **kwargs):
@@ -96,8 +96,8 @@ class DDPSpawnPlugin(DDPS):
                 rank=int(global_rank),
                 world_size=int(world_size),
                 dist_backend=self.torch_distributed_backend,
-                dist_init_method="tcp://{}:{}".format(master_addr, master_port),
-                rpc_init_method="tcp://{}:{}".format(master_addr, int(master_port) + 1),
+                dist_init_method=f"tcp://{master_addr}:{master_port}",
+                rpc_init_method=f"tcp://{master_addr}:{int(master_port) + 1}",
             )
 
     def training_step(self, *args, **kwargs):

--- a/machin/env/wrappers/openai_gym.py
+++ b/machin/env/wrappers/openai_gym.py
@@ -15,7 +15,7 @@ from ..utils.openai_gym import disable_view_window
 
 class GymTerminationError(Exception):
     def __init__(self):
-        super(GymTerminationError, self).__init__(
+        super().__init__(
             "One or several environments have terminated, " "reset before continuing."
         )
 
@@ -33,7 +33,7 @@ class ParallelWrapperDummy(ParallelWrapperBase):
             env_creators: List of gym environment creators, used to create
                 environments, accepts a index as your environment id.
         """
-        super(ParallelWrapperDummy, self).__init__()
+        super().__init__()
         self._envs = [ec(i) for ec, i in zip(env_creators, range(len(env_creators)))]
         self._terminal = np.zeros([len(self._envs)], dtype=np.bool)
 
@@ -184,7 +184,7 @@ class ParallelWrapperSubProc(ParallelWrapperBase):
                 environments on sub process workers, accepts a index as your
                 environment id.
         """
-        super(ParallelWrapperSubProc, self).__init__()
+        super().__init__()
         self.workers = []
 
         # Some environments will hang or collapse when using fork context.

--- a/machin/env/wrappers/openai_gym.py
+++ b/machin/env/wrappers/openai_gym.py
@@ -369,12 +369,10 @@ class ParallelWrapperSubProc(ParallelWrapperBase):
             if worker.exitcode is None:
                 continue
             if worker.exitcode == 2:
-                raise RuntimeError(
-                    "Worker {} failed to create environment.".format(worker_id)
-                )
+                raise RuntimeError(f"Worker {worker_id} failed to create environment.")
             elif worker.exitcode != 0:
                 raise RuntimeError(
-                    "Worker {} exited with code {}.".format(worker_id, worker.exitcode)
+                    f"Worker {worker_id} exited with code {worker.exitcode}."
                 )
 
         for env_idx, i in zip(env_idxs, range(len(env_idxs))):

--- a/machin/frame/algorithms/a2c.py
+++ b/machin/frame/algorithms/a2c.py
@@ -208,7 +208,7 @@ class A2C(TorchFramework):
 
         self.criterion = criterion
 
-        super(A2C, self).__init__()
+        super().__init__()
 
     @property
     def optimizers(self):

--- a/machin/frame/algorithms/a3c.py
+++ b/machin/frame/algorithms/a3c.py
@@ -85,7 +85,7 @@ class A3C(A2C):
         """
         # Adam is just a placeholder here, the actual optimizer is
         # set in parameter servers
-        super(A3C, self).__init__(
+        super().__init__(
             actor,
             critic,
             FakeOptimizer,
@@ -134,19 +134,19 @@ class A3C(A2C):
         # DOC INHERITED
         if self.is_syncing:
             self.actor_grad_server.pull(self.actor)
-        return super(A3C, self).act(state)
+        return super().act(state)
 
     def _eval_act(self, state: Dict[str, Any], action: Dict[str, Any], **__):
         # DOC INHERITED
         if self.is_syncing:
             self.actor_grad_server.pull(self.actor)
-        return super(A3C, self)._eval_act(state, action)
+        return super()._eval_act(state, action)
 
     def _criticize(self, state: Dict[str, Any], *_, **__):
         # DOC INHERITED
         if self.is_syncing:
             self.critic_grad_server.pull(self.critic)
-        return super(A3C, self)._criticize(state)
+        return super()._criticize(state)
 
     def update(
         self, update_value=True, update_policy=True, concatenate_samples=True, **__
@@ -154,7 +154,7 @@ class A3C(A2C):
         # DOC INHERITED
         org_sync = self.is_syncing
         self.is_syncing = False
-        super(A3C, self).update(update_value, update_policy, concatenate_samples)
+        super().update(update_value, update_policy, concatenate_samples)
         self.is_syncing = org_sync
         self.actor_grad_server.push(self.actor)
         self.critic_grad_server.push(self.critic)

--- a/machin/frame/algorithms/apex.py
+++ b/machin/frame/algorithms/apex.py
@@ -77,7 +77,7 @@ class DQNApex(DQNPer):
             gradient_max: Maximum gradient.
             replay_size: Local replay buffer size of a single worker.
         """
-        super(DQNApex, self).__init__(
+        super().__init__(
             qnet,
             qnet_target,
             optimizer,
@@ -116,7 +116,7 @@ class DQNApex(DQNPer):
         # DOC INHERITED
         if self.is_syncing and not use_target:
             self.qnet_model_server.pull(self.qnet)
-        return super(DQNApex, self).act_discrete(state, use_target)
+        return super().act_discrete(state, use_target)
 
     def act_discrete_with_noise(
         self,
@@ -128,17 +128,13 @@ class DQNApex(DQNPer):
         # DOC INHERITED
         if self.is_syncing and not use_target:
             self.qnet_model_server.pull(self.qnet)
-        return super(DQNApex, self).act_discrete_with_noise(
-            state, use_target, decay_epsilon
-        )
+        return super().act_discrete_with_noise(state, use_target, decay_epsilon)
 
     def update(
         self, update_value=True, update_target=True, concatenate_samples=True, **__
     ):
         # DOC INHERITED
-        result = super(DQNApex, self).update(
-            update_value, update_target, concatenate_samples
-        )
+        result = super().update(update_value, update_target, concatenate_samples)
         if isinstance(
             self.qnet, (nn.parallel.DataParallel, nn.parallel.DistributedDataParallel)
         ):
@@ -316,7 +312,7 @@ class DDPGApex(DDPGPer):
             gradient_max: Maximum gradient.
             replay_size: Local replay buffer size of a single worker.
         """
-        super(DDPGApex, self).__init__(
+        super().__init__(
             actor,
             actor_target,
             critic,
@@ -357,7 +353,7 @@ class DDPGApex(DDPGPer):
         # DOC INHERITED
         if self.is_syncing and not use_target:
             self.actor_model_server.pull(self.actor)
-        return super(DDPGApex, self).act(state, use_target)
+        return super().act(state, use_target)
 
     def act_with_noise(
         self,
@@ -371,7 +367,7 @@ class DDPGApex(DDPGPer):
         # DOC INHERITED
         if self.is_syncing and not use_target:
             self.actor_model_server.pull(self.actor)
-        return super(DDPGApex, self).act_with_noise(
+        return super().act_with_noise(
             state,
             noise_param=noise_param,
             ratio=ratio,
@@ -383,7 +379,7 @@ class DDPGApex(DDPGPer):
         # DOC INHERITED
         if self.is_syncing and not use_target:
             self.actor_model_server.pull(self.actor)
-        return super(DDPGApex, self).act_discrete(state, use_target)
+        return super().act_discrete(state, use_target)
 
     def act_discrete_with_noise(
         self, state: Dict[str, Any], use_target: bool = False, **__
@@ -391,7 +387,7 @@ class DDPGApex(DDPGPer):
         # DOC INHERITED
         if self.is_syncing and not use_target:
             self.actor_model_server.pull(self.actor)
-        return super(DDPGApex, self).act_discrete_with_noise(state, use_target)
+        return super().act_discrete_with_noise(state, use_target)
 
     def update(
         self,
@@ -402,7 +398,7 @@ class DDPGApex(DDPGPer):
         **__
     ):
         # DOC INHERITED
-        result = super(DDPGApex, self).update(
+        result = super().update(
             update_value, update_policy, update_target, concatenate_samples
         )
         if isinstance(

--- a/machin/frame/algorithms/ars.py
+++ b/machin/frame/algorithms/ars.py
@@ -21,7 +21,7 @@ from .utils import (
 )
 
 
-class RunningStat(object):
+class RunningStat:
     """
     Running status estimator method by B. P. Welford
     described in http://www.johndcook.com/blog/standard_deviation/
@@ -128,7 +128,7 @@ class RunningStat(object):
         return self._M.shape
 
 
-class MeanStdFilter(object):
+class MeanStdFilter:
     """Keeps track of a running mean for seen states"""
 
     def __init__(self, shape):
@@ -240,7 +240,7 @@ class MeanStdFilter(object):
         )
 
 
-class SharedNoiseSampler(object):
+class SharedNoiseSampler:
     def __init__(self, noise: t.Tensor, seed: int):
         """
         Args:
@@ -414,7 +414,7 @@ class ARS(TorchFramework):
         self._sync_actor()
         self._generate_parameter()
         self._reset_reward_dict()
-        super(ARS, self).__init__()
+        super().__init__()
 
     @property
     def optimizers(self):

--- a/machin/frame/algorithms/ars.py
+++ b/machin/frame/algorithms/ars.py
@@ -293,7 +293,7 @@ class ARS(TorchFramework):
         normalize_state: bool = True,
         noise_seed: int = 12345,
         sample_seed: int = 123,
-        **__
+        **__,
     ):
         """
 
@@ -520,12 +520,12 @@ class ARS(TorchFramework):
 
         # collect result in manager process
         self.ars_group.pair(
-            "ars/rollout_result/{}".format(self.ars_group.get_cur_name()),
+            f"ars/rollout_result/{self.ars_group.get_cur_name()}",
             [pos_reward, neg_reward, delta_idx],
         )
         if self.normalize_state:
             self.ars_group.pair(
-                "ars/filter/{}".format(self.ars_group.get_cur_name()), self.filter
+                f"ars/filter/{self.ars_group.get_cur_name()}", self.filter
             )
         self.ars_group.barrier()
 
@@ -587,11 +587,9 @@ class ARS(TorchFramework):
                     self.filter[k].clear_local()
 
         self.ars_group.barrier()
-        self.ars_group.unpair(
-            "ars/rollout_result/{}".format(self.ars_group.get_cur_name())
-        )
+        self.ars_group.unpair(f"ars/rollout_result/{self.ars_group.get_cur_name()}")
         if self.normalize_state:
-            self.ars_group.unpair("ars/filter/{}".format(self.ars_group.get_cur_name()))
+            self.ars_group.unpair(f"ars/filter/{self.ars_group.get_cur_name()}")
         self.ars_group.barrier()
 
         # synchronize filter states across all workers (and the manager)

--- a/machin/frame/algorithms/base.py
+++ b/machin/frame/algorithms/base.py
@@ -149,14 +149,14 @@ class TorchFramework:
             if r in network_map:
                 t.save(
                     getattr(self, r),
-                    join(model_dir, "{}_{}.pt".format(network_map[r], version)),
+                    join(model_dir, f"{network_map[r]}_{version}.pt"),
                 )
             else:
                 default_logger.warning(
                     'Save name for module "{}" is not '
                     "specified, module name is used.".format(r)
                 )
-                t.save(getattr(self, r), join(model_dir, "{}_{}.pt".format(r, version)))
+                t.save(getattr(self, r), join(model_dir, f"{r}_{version}.pt"))
 
     def visualize_model(self, final_tensor: t.Tensor, name: str, directory: str):
         if name in self._visualized:

--- a/machin/frame/algorithms/ddpg.py
+++ b/machin/frame/algorithms/ddpg.py
@@ -173,7 +173,7 @@ class DDPG(TorchFramework):
             )
 
         self.criterion = criterion
-        super(DDPG, self).__init__()
+        super().__init__()
 
     @property
     def optimizers(self):
@@ -479,7 +479,7 @@ class DDPG(TorchFramework):
         self, model_dir: str, network_map: Dict[str, str] = None, version: int = -1
     ):
         # DOC INHERITED
-        super(DDPG, self).load(model_dir, network_map, version)
+        super().load(model_dir, network_map, version)
         with t.no_grad():
             hard_update(self.actor, self.actor_target)
             hard_update(self.critic, self.critic_target)

--- a/machin/frame/algorithms/ddpg_per.py
+++ b/machin/frame/algorithms/ddpg_per.py
@@ -46,7 +46,7 @@ class DDPGPer(DDPG):
         **__
     ):
         # DOC INHERITED
-        super(DDPGPer, self).__init__(
+        super().__init__(
             actor,
             actor_target,
             critic,

--- a/machin/frame/algorithms/dqn.py
+++ b/machin/frame/algorithms/dqn.py
@@ -49,7 +49,7 @@ class DQN(TorchFramework):
         mode: str = "double",
         visualize: bool = False,
         visualize_dir: str = "",
-        **__
+        **__,
     ):
         """
         Note:
@@ -173,7 +173,7 @@ edu/class/psych209/Readings/MnihEtAlHassibis15NatureControlDeepRL.pdf>`__ essay.
         self._update_counter = 0
 
         if mode not in {"vanilla", "fixed_target", "double"}:
-            raise ValueError("Unknown DQN mode: {}".format(mode))
+            raise ValueError(f"Unknown DQN mode: {mode}")
 
         if update_rate is not None and update_steps is not None:
             raise ValueError(
@@ -254,7 +254,7 @@ edu/class/psych209/Readings/MnihEtAlHassibis15NatureControlDeepRL.pdf>`__ essay.
         state: Dict[str, Any],
         use_target: bool = False,
         decay_epsilon: bool = True,
-        **__
+        **__,
     ):
         """
         Randomly selects an action from the action space according
@@ -480,7 +480,7 @@ edu/class/psych209/Readings/MnihEtAlHassibis15NatureControlDeepRL.pdf>`__ essay.
                         hard_update(self.qnet_target, self.qnet)
 
         else:
-            raise ValueError("Unknown DQN mode: {}".format(self.mode))
+            raise ValueError(f"Unknown DQN mode: {self.mode}")
 
         self.qnet.eval()
         # use .item() to prevent memory leakage

--- a/machin/frame/algorithms/dqn.py
+++ b/machin/frame/algorithms/dqn.py
@@ -209,7 +209,7 @@ edu/class/psych209/Readings/MnihEtAlHassibis15NatureControlDeepRL.pdf>`__ essay.
 
         self.criterion = criterion
 
-        super(DQN, self).__init__()
+        super().__init__()
 
     @property
     def optimizers(self):
@@ -495,7 +495,7 @@ edu/class/psych209/Readings/MnihEtAlHassibis15NatureControlDeepRL.pdf>`__ essay.
 
     def load(self, model_dir, network_map=None, version=-1):
         # DOC INHERITED
-        super(DQN, self).load(model_dir, network_map, version)
+        super().load(model_dir, network_map, version)
         with t.no_grad():
             hard_update(self.qnet, self.qnet_target)
 

--- a/machin/frame/algorithms/dqn_per.py
+++ b/machin/frame/algorithms/dqn_per.py
@@ -44,7 +44,7 @@ class DQNPer(DQN):
         **__
     ):
         # DOC INHERITED
-        super(DQNPer, self).__init__(
+        super().__init__(
             qnet,
             qnet_target,
             optimizer,

--- a/machin/frame/algorithms/hddpg.py
+++ b/machin/frame/algorithms/hddpg.py
@@ -69,7 +69,7 @@ class HDDPG(DDPG):
             visualize: Whether visualize the network flow in the first pass.
             visualize_dir: Visualized graph save directory.
         """
-        super(HDDPG, self).__init__(
+        super().__init__(
             actor,
             actor_target,
             critic,

--- a/machin/frame/algorithms/impala.py
+++ b/machin/frame/algorithms/impala.py
@@ -81,9 +81,7 @@ class EpisodeDistributedBuffer(DistributedBuffer):
         ),
     ):
         transition = EpisodeTransition(**transition)
-        super(EpisodeDistributedBuffer, self).append(
-            transition, required_attrs=required_attrs
-        )
+        super().append(transition, required_attrs=required_attrs)
 
 
 class IMPALA(TorchFramework):
@@ -177,7 +175,7 @@ class IMPALA(TorchFramework):
 
         self.criterion = criterion
 
-        super(IMPALA, self).__init__()
+        super().__init__()
 
     @property
     def optimizers(self):

--- a/machin/frame/algorithms/maddpg.py
+++ b/machin/frame/algorithms/maddpg.py
@@ -31,7 +31,7 @@ class SHMBuffer(Buffer):
                     result.share_memory_()
                     return result
                 except Exception:
-                    raise ValueError("Batch not concatenable: {}".format(batch))
+                    raise ValueError(f"Batch not concatenable: {batch}")
         else:
             for it in batch:
                 if t.is_tensor(it):
@@ -81,7 +81,7 @@ class MADDPG(TorchFramework):
         use_jit: bool = True,
         pool_type: str = "thread",
         pool_size: int = None,
-        **__
+        **__,
     ):
         """
         See Also:
@@ -233,11 +233,11 @@ class MADDPG(TorchFramework):
         for ac, idx in zip(self.actor_targets, range(len(actors))):
             for acc, idxx in zip(ac, range(self.ensemble_size)):
                 acc.share_memory()
-                self.all_actor_target.add_module("actor_{}_{}".format(idx, idxx), acc)
+                self.all_actor_target.add_module(f"actor_{idx}_{idxx}", acc)
 
         for cr, idx in zip(self.critic_targets, range(len(critics))):
             cr.share_memory()
-            self.all_critic_target.add_module("critic_{}".format(idx), cr)
+            self.all_critic_target.add_module(f"critic_{idx}", cr)
 
         # Make sure target and online networks have the same weight
         with t.no_grad():
@@ -343,7 +343,7 @@ class MADDPG(TorchFramework):
         ratio: float = 1.0,
         mode: str = "uniform",
         use_target: bool = False,
-        **__
+        **__,
     ):
         """
         Use all actor networks to produce noisy actions for the current state.
@@ -867,9 +867,7 @@ class MADDPG(TorchFramework):
 
         if visualize:
             # only invoked if not running by pool
-            MADDPG._visualize(
-                value_loss, "critic_{}".format(actor_index), visualize_dir
-            )
+            MADDPG._visualize(value_loss, f"critic_{actor_index}", visualize_dir)
 
         if update_value:
             critics[actor_index].zero_grad()
@@ -905,7 +903,7 @@ class MADDPG(TorchFramework):
             # only invoked if not running by pool
             MADDPG._visualize(
                 act_policy_loss,
-                "actor_{}_{}".format(actor_index, policy_index),
+                f"actor_{actor_index}_{policy_index}",
                 visualize_dir,
             )
 

--- a/machin/frame/algorithms/maddpg.py
+++ b/machin/frame/algorithms/maddpg.py
@@ -297,7 +297,7 @@ class MADDPG(TorchFramework):
                 self.jit_actors.append(jit_actors)
                 self.jit_actor_targets.append(jit_actor_targets)
 
-        super(MADDPG, self).__init__()
+        super().__init__()
 
     @property
     def optimizers(self):
@@ -667,7 +667,7 @@ class MADDPG(TorchFramework):
 
     def load(self, model_dir, network_map=None, version=-1):
         # DOC INHERITED
-        super(MADDPG, self).load(model_dir, network_map, version)
+        super().load(model_dir, network_map, version)
         with t.no_grad():
             self.pool.starmap(
                 hard_update,

--- a/machin/frame/algorithms/ppo.py
+++ b/machin/frame/algorithms/ppo.py
@@ -73,7 +73,7 @@ class PPO(A2C):
             visualize: Whether visualize the network flow in the first pass.
             visualize_dir: Visualized graph save directory.
         """
-        super(PPO, self).__init__(
+        super().__init__(
             actor,
             critic,
             optimizer,

--- a/machin/frame/algorithms/rainbow.py
+++ b/machin/frame/algorithms/rainbow.py
@@ -81,7 +81,7 @@ class RAINBOW(DQN):
             mode: one of ``"vanilla", "fixed_target", "double"``.
             visualize: Whether visualize the network flow in the first pass.
         """
-        super(RAINBOW, self).__init__(
+        super().__init__(
             qnet,
             qnet_target,
             optimizer,

--- a/machin/frame/algorithms/sac.py
+++ b/machin/frame/algorithms/sac.py
@@ -181,7 +181,7 @@ class SAC(TorchFramework):
             )
 
         self.criterion = criterion
-        super(SAC, self).__init__()
+        super().__init__()
 
     @property
     def optimizers(self):
@@ -421,7 +421,7 @@ class SAC(TorchFramework):
 
     def load(self, model_dir, network_map=None, version=-1):
         # DOC INHERITED
-        super(SAC, self).load(model_dir, network_map, version)
+        super().load(model_dir, network_map, version)
         with t.no_grad():
             hard_update(self.critic, self.critic_target)
             hard_update(self.critic, self.critic2_target)

--- a/machin/frame/algorithms/td3.py
+++ b/machin/frame/algorithms/td3.py
@@ -87,7 +87,7 @@ class TD3(DDPG):
         if lr_scheduler_kwargs is None:
             lr_scheduler_kwargs = ({}, {}, {})
 
-        super(TD3, self).__init__(
+        super().__init__(
             actor,
             actor_target,
             critic,
@@ -275,7 +275,7 @@ class TD3(DDPG):
         """
         if hasattr(self, "critic2_lr_sch"):
             self.critic2_lr_sch.step()
-        super(TD3, self).update_lr_scheduler()
+        super().update_lr_scheduler()
 
     def load(
         self, model_dir: str, network_map: Dict[str, str] = None, version: int = -1

--- a/machin/frame/algorithms/utils.py
+++ b/machin/frame/algorithms/utils.py
@@ -284,7 +284,7 @@ class FakeOptimizer(torch.optim.Optimizer):
     """
 
     def __init__(self, params, *_, **__):
-        super(FakeOptimizer, self).__init__(params, {})
+        super().__init__(params, {})
 
     def step(self, *args, **kwargs):
         pass

--- a/machin/frame/buffers/buffer.py
+++ b/machin/frame/buffers/buffer.py
@@ -9,7 +9,7 @@ import torch as t
 import random
 
 
-class Buffer(object):
+class Buffer:
     def __init__(self, buffer_size, buffer_device="cpu", *_, **__):
         """
         Create a buffer instance.

--- a/machin/frame/buffers/buffer.py
+++ b/machin/frame/buffers/buffer.py
@@ -64,9 +64,7 @@ class Buffer(object):
             )
         if not transition.has_keys(required_attrs):
             missing_keys = set(required_attrs) - set(transition.keys())
-            raise ValueError(
-                "Transition object missing attributes: {}".format(missing_keys)
-            )
+            raise ValueError(f"Transition object missing attributes: {missing_keys}")
         transition.to(self.buffer_device)
 
         if self.size() != 0 and self.buffer[0].keys() != transition.keys():
@@ -136,7 +134,7 @@ class Buffer(object):
         sample_attrs: List[str] = None,
         additional_concat_attrs: List[str] = None,
         *_,
-        **__
+        **__,
     ) -> Any:
         """
         Sample a random batch from buffer.
@@ -204,7 +202,7 @@ class Buffer(object):
         if isinstance(sample_method, str):
             if not hasattr(self, "sample_method_" + sample_method):
                 raise RuntimeError(
-                    "Cannot find specified sample method: {}".format(sample_method)
+                    f"Cannot find specified sample method: {sample_method}"
                 )
             sample_method = getattr(self, "sample_method_" + sample_method)
         batch_size, batch = sample_method(self.buffer, batch_size)
@@ -316,7 +314,7 @@ class Buffer(object):
                 try:
                     return t.tensor(batch, device=device).view(batch_size, -1)
                 except Exception:
-                    raise ValueError("Batch not concatenable: {}".format(batch))
+                    raise ValueError(f"Batch not concatenable: {batch}")
         else:
             return batch
 

--- a/machin/frame/buffers/buffer_d.py
+++ b/machin/frame/buffers/buffer_d.py
@@ -41,7 +41,7 @@ class DistributedBuffer(Buffer):
             group: Process group which holds this buffer.
             buffer_name: A unique name of your buffer.
         """
-        super(DistributedBuffer, self).__init__(buffer_size, "cpu")
+        super().__init__(buffer_size, "cpu")
         self.buffer_name = buffer_name
         self.group = group
 
@@ -65,16 +65,14 @@ class DistributedBuffer(Buffer):
     ):
         # DOC INHERITED
         with self.wr_lock:
-            super(DistributedBuffer, self).append(
-                transition, required_attrs=required_attrs
-            )
+            super().append(transition, required_attrs=required_attrs)
 
     def clear(self):
         """
         Clear current local buffer.
         """
         with self.wr_lock:
-            return super(DistributedBuffer, self).clear()
+            return super().clear()
 
     def all_clear(self):
         """
@@ -93,7 +91,7 @@ class DistributedBuffer(Buffer):
             Length of current local buffer.
         """
         with self.wr_lock:
-            return super(DistributedBuffer, self).size()
+            return super().size()
 
     def all_size(self):
         """

--- a/machin/frame/buffers/buffer_d.py
+++ b/machin/frame/buffers/buffer_d.py
@@ -121,7 +121,7 @@ class DistributedBuffer(Buffer):
         sample_attrs: List[str] = None,
         additional_concat_attrs: List[str] = None,
         *_,
-        **__
+        **__,
     ) -> Any:
         # DOC INHERITED
         p_num = self.group.size()
@@ -160,7 +160,7 @@ class DistributedBuffer(Buffer):
         if isinstance(sample_method, str):
             if not hasattr(self, "sample_method_" + sample_method):
                 raise RuntimeError(
-                    "Cannot find specified sample method: {}".format(sample_method)
+                    f"Cannot find specified sample method: {sample_method}"
                 )
             sample_method = getattr(self, "sample_method_" + sample_method)
 

--- a/machin/frame/buffers/prioritized_buffer.py
+++ b/machin/frame/buffers/prioritized_buffer.py
@@ -263,7 +263,7 @@ class PrioritizedBuffer(Buffer):
             beta_increment_per_sampling:
                 Beta increase step size, will gradually increase ``beta`` to 1.
         """
-        super(PrioritizedBuffer, self).__init__(buffer_size, buffer_device)
+        super().__init__(buffer_size, buffer_device)
         self.epsilon = epsilon
         self.alpha = alpha
         self.beta = beta
@@ -291,7 +291,7 @@ class PrioritizedBuffer(Buffer):
             priority: Priority of transition.
             required_attrs: Required attributes.
         """
-        position = super(PrioritizedBuffer, self).append(transition, required_attrs)
+        position = super().append(transition, required_attrs)
         if priority is None:
             # the initialization method used in the original essay
             priority = self.wt_tree.get_leaf_max()

--- a/machin/frame/buffers/prioritized_buffer.py
+++ b/machin/frame/buffers/prioritized_buffer.py
@@ -205,7 +205,7 @@ class WeightTree:
         Args:
             precision: Number of digits of weights to print.
         """
-        fmt = "{{:.{}f}}".format(precision)
+        fmt = f"{{:.{precision}f}}"
         for i in range(self.depth):
             offset, size = self.offsets[i], self.sizes[i]
             weights = [
@@ -241,7 +241,7 @@ class PrioritizedBuffer(Buffer):
         beta=0.4,
         beta_increment_per_sampling=0.001,
         *_,
-        **__
+        **__,
     ):
         """
         Args:
@@ -331,7 +331,7 @@ class PrioritizedBuffer(Buffer):
         sample_attrs: List[str] = None,
         additional_concat_attrs: List[str] = None,
         *_,
-        **__
+        **__,
     ) -> Any:
         """
         Sample the most important batch from the prioritized buffer.

--- a/machin/frame/buffers/prioritized_buffer_d.py
+++ b/machin/frame/buffers/prioritized_buffer_d.py
@@ -45,7 +45,7 @@ class DistributedPrioritizedBuffer(PrioritizedBuffer):
             buffer_size: Maximum local buffer size.
             group: Process group which holds this buffer.
         """
-        super(DistributedPrioritizedBuffer, self).__init__(buffer_size, "cpu")
+        super().__init__(buffer_size, "cpu")
         self.buffer_name = buffer_name
         self.buffer_version_table = np.zeros([buffer_size], dtype=np.uint64)
         self.group = group
@@ -93,7 +93,7 @@ class DistributedPrioritizedBuffer(PrioritizedBuffer):
             Length of current local buffer.
         """
         with self.wr_lock:
-            return super(DistributedPrioritizedBuffer, self).size()
+            return super().size()
 
     def all_size(self):
         """
@@ -117,7 +117,7 @@ class DistributedPrioritizedBuffer(PrioritizedBuffer):
         Remove all entries from current local buffer.
         """
         with self.wr_lock:
-            super(DistributedPrioritizedBuffer, self).clear()
+            super().clear()
             # also clear the version table
             self.buffer_version_table.fill(0)
 
@@ -214,11 +214,11 @@ class DistributedPrioritizedBuffer(PrioritizedBuffer):
 
     def _size_service(self):  # pragma: no cover
         with self.wr_lock:
-            return super(DistributedPrioritizedBuffer, self).size()
+            return super().size()
 
     def _clear_service(self):  # pragma: no cover
         with self.wr_lock:
-            super(DistributedPrioritizedBuffer, self).clear()
+            super().clear()
             # also clear the version table
             self.buffer_version_table.fill(0)
 
@@ -235,9 +235,7 @@ class DistributedPrioritizedBuffer(PrioritizedBuffer):
             # select unchanged entries
             priorities = priorities[is_same]
             indexes = indexes[is_same]
-            super(DistributedPrioritizedBuffer, self).update_priority(
-                priorities, indexes
-            )
+            super().update_priority(priorities, indexes)
 
     def _sample_service(self, batch_size, all_weight_sum):  # pragma: no cover
         # the local batch size

--- a/machin/frame/noise/generator.py
+++ b/machin/frame/noise/generator.py
@@ -58,7 +58,7 @@ class NormalNoiseGen(NoiseGen):
             return self.dist.sample(self.shape)
 
     def __repr__(self):
-        return "NormalNoise(mu={}, sigma={})".format(self.mu, self.sigma)
+        return f"NormalNoise(mu={self.mu}, sigma={self.sigma})"
 
 
 class ClippedNormalNoiseGen(NoiseGen):
@@ -131,7 +131,7 @@ class UniformNoiseGen(NoiseGen):
             return self.dist.sample(self.shape)
 
     def __repr__(self):
-        return "UniformNoise(min={}, max={})".format(self.min, self.max)
+        return f"UniformNoise(min={self.min}, max={self.max})"
 
 
 class OrnsteinUhlenbeckNoiseGen(NoiseGen):
@@ -199,4 +199,4 @@ class OrnsteinUhlenbeckNoiseGen(NoiseGen):
         self.x_prev = self.x0 if self.x0 is not None else t.zeros(self.shape)
 
     def __repr__(self):
-        return "OrnsteinUhlenbeckNoise(mu={}, sigma={})".format(self.mu, self.sigma)
+        return f"OrnsteinUhlenbeckNoise(mu={self.mu}, sigma={self.sigma})"

--- a/machin/frame/noise/param_space_noise.py
+++ b/machin/frame/noise/param_space_noise.py
@@ -7,7 +7,7 @@ from machin.utils.helper_classes import Switch
 from .generator import NormalNoiseGen
 
 
-class AdaptiveParamNoise(object):
+class AdaptiveParamNoise:
     def __init__(
         self,
         initial_stddev: float = 0.1,
@@ -154,7 +154,7 @@ def perturb_model(
         backward pass, and you can safely call optimizers afterwards.
 
     Hint:
-        1. ``noise_generator`` must accept (shape, \*args) in its ``__init__``
+        1. ``noise_generator`` must accept (shape, \\*args) in its ``__init__``
         function, where shape is the required shape. it also needs to have
         ``__call__(device=None)`` which produce a noise tensor on the specified
         device when invoked.

--- a/machin/frame/noise/param_space_noise.py
+++ b/machin/frame/noise/param_space_noise.py
@@ -117,7 +117,7 @@ def _add_perturb_hook(
             # Called before backward update, swap noisy parameters out,
             # so gradients are applied to original parameters.
             if debug_backward:
-                print("Backward swapped for {}!".format(param_name))
+                print(f"Backward swapped for {param_name}!")
             with t.no_grad():
                 if org_params and t.is_tensor(param_value):
                     param_value.set_(org_params[param_name])
@@ -273,10 +273,8 @@ def perturb_model(
                 )
                 tmp_action.clear()
                 param_noise_spec.adapt(dist)
-                logger.info("Current output distance: {}".format(dist))
-                logger.info(
-                    "Current param noise stddev: {}".format(param_noise_spec.get_dev())
-                )
+                logger.info(f"Current output distance: {dist}")
+                logger.info(f"Current param noise stddev: {param_noise_spec.get_dev()}")
 
     # Boise generation happens in pre-forward and noise adjust happens
     # in post-forward

--- a/machin/frame/transition.py
+++ b/machin/frame/transition.py
@@ -7,7 +7,7 @@ import numpy as np
 Scalar = NewType("Scalar", Union[int, float, bool])
 
 
-class TransitionBase(object):
+class TransitionBase:
     """
     Base class for all transitions
     """
@@ -267,7 +267,7 @@ class Transition(TransitionBase):
         assert isinstance(terminal, bool) or (
             t.is_tensor(terminal) and terminal.dtype == t.bool
         )
-        super(Transition, self).__init__(
+        super().__init__(
             major_attr=["state", "action", "next_state"],
             sub_attr=["reward", "terminal"],
             custom_attr=custom_keys,
@@ -278,7 +278,7 @@ class Transition(TransitionBase):
 
     def _check_validity(self):
         # fix batch size to 1
-        super(Transition, self)._check_validity()
+        super()._check_validity()
         if self._batch_size != 1:
             raise ValueError(
                 "Batch size of the default transition "
@@ -300,7 +300,7 @@ class TransitionStorageBasic(list):
         """
         self.max_size = max_size
         self.index = 0
-        super(TransitionStorageBasic, self).__init__()
+        super().__init__()
 
     def store(self, transition: TransitionBase) -> int:
         """
@@ -325,7 +325,7 @@ class TransitionStorageBasic(list):
         return position
 
     def clear(self):
-        super(TransitionStorageBasic, self).clear()
+        super().clear()
 
 
 class TransitionStorageSmart(TransitionStorageBasic):
@@ -344,7 +344,7 @@ class TransitionStorageSmart(TransitionStorageBasic):
 
     def __init__(self, max_size):
         # DOC INHERITED
-        super(TransitionStorageSmart, self).__init__(max_size)
+        super().__init__(max_size)
 
     def store(self, transition: TransitionBase) -> int:
         # DOC INHERITED
@@ -392,4 +392,4 @@ class TransitionStorageSmart(TransitionStorageBasic):
         return position
 
     def clear(self):
-        super(TransitionStorageSmart, self).clear()
+        super().clear()

--- a/machin/model/nets/base.py
+++ b/machin/model/nets/base.py
@@ -13,7 +13,7 @@ class NeuralNetworkModule(nn.Module, ABC):
     """
 
     def __init__(self):
-        super(NeuralNetworkModule, self).__init__()
+        super().__init__()
         self.input_module = None
         self.output_module = None
 

--- a/machin/model/nets/resnet.py
+++ b/machin/model/nets/resnet.py
@@ -85,7 +85,7 @@ class BasicBlock(NeuralNetworkModule):
         """
         if norm_layer is None:
             norm_layer = nn.BatchNorm2d
-        super(BasicBlock, self).__init__()
+        super().__init__()
         self.conv1 = conv3x3(in_planes, out_planes, stride)
         self.bn1 = norm_layer(out_planes)
         self.conv2 = conv3x3(out_planes, self.expansion * out_planes)
@@ -128,7 +128,7 @@ class Bottleneck(NeuralNetworkModule):
         """
         if norm_layer is None:
             norm_layer = nn.BatchNorm2d
-        super(Bottleneck, self).__init__()
+        super().__init__()
         self.conv1 = conv1x1(in_planes, out_planes)
         self.conv2 = conv3x3(out_planes, out_planes, stride=stride)
         self.conv3 = conv1x1(out_planes, self.expansion * out_planes)
@@ -172,7 +172,7 @@ class BasicBlockWN(NeuralNetworkModule):
             out_planes: Number of output planes.
             stride:     Stride of convolution.
         """
-        super(BasicBlockWN, self).__init__()
+        super().__init__()
         self.conv1 = weight_norm(conv3x3(in_planes, out_planes, stride))
         self.conv2 = weight_norm(conv3x3(out_planes, self.expansion * out_planes))
         # Create a shortcut from input to output.
@@ -213,7 +213,7 @@ class BottleneckWN(NeuralNetworkModule):
             out_planes: Number of output planes.
             stride:     Stride of convolution.
         """
-        super(BottleneckWN, self).__init__()
+        super().__init__()
         self.conv1 = weight_norm(
             nn.Conv2d(in_planes, out_planes, kernel_size=1, bias=False)
         )
@@ -272,7 +272,7 @@ class ResNet(NeuralNetworkModule):
             norm: Normalization method, could be one of "none", "batch" or
                 "weight".
         """
-        super(ResNet, self).__init__()
+        super().__init__()
         self.norm = norm
         self.depth = depth
         self.in_planes = in_planes

--- a/machin/model/nets/resnet.py
+++ b/machin/model/nets/resnet.py
@@ -66,7 +66,7 @@ def cfg(depth, norm="none"):
             "152": (Bottleneck, [3, 8, 36, 3], {"norm_layer": none_norm}),
         }
     else:
-        raise ValueError('Invalid normalization method: "{}"'.format(norm))
+        raise ValueError(f'Invalid normalization method: "{norm}"')
     return cfg_dict[str(depth)]
 
 

--- a/machin/parallel/assigner.py
+++ b/machin/parallel/assigner.py
@@ -188,7 +188,7 @@ class ModelAssigner:
             for dev in devices:
                 if dev.type == "cuda" and dev not in available_devices:
                     default_logger.info(
-                        "Warning: device {} not available, removed.".format(dev)
+                        f"Warning: device {dev} not available, removed."
                     )
                 else:
                     used_devices.append(dev)
@@ -197,7 +197,7 @@ class ModelAssigner:
         if not devices:
             devices = [t.device("cpu")]
 
-        default_logger.info("Using these devices: {}".format(devices))
+        default_logger.info(f"Using these devices: {devices}")
 
         sizes = [
             ModelSizeEstimator(model, model_size_multiplier).estimate_size()

--- a/machin/parallel/distributed/world.py
+++ b/machin/parallel/distributed/world.py
@@ -358,7 +358,7 @@ class World:
                 )
             )
         if group_name in self.groups:  # pragma: no cover
-            raise RuntimeError("Group {} already exists!".format(group_name))
+            raise RuntimeError(f"Group {group_name} already exists!")
         group = RpcGroup(group_name, members)
 
         # set the group
@@ -625,9 +625,7 @@ class RpcGroup:
         """
         if key in self.group_value_lut:
             raise KeyError(
-                'Value with key "{}" already paired to Group [{}]'.format(
-                    key, self.group_name
-                )
+                f'Value with key "{key}" already paired to Group [{self.group_name}]'
             )
         # announce the pairing
         status = rpc.rpc_sync(
@@ -639,9 +637,7 @@ class RpcGroup:
             self.group_value_lut[key] = value
         else:
             raise KeyError(
-                'Value with key "{}" already paired to Group [{}]'.format(
-                    key, self.group_name
-                )
+                f'Value with key "{key}" already paired to Group [{self.group_name}]'
             )
 
     @_check_executor
@@ -715,9 +711,7 @@ class RpcGroup:
             )
             if not status:
                 raise KeyError(
-                    "Value with key [{}] not found on Group [{}], ".format(
-                        key, self.group_name
-                    )
+                    f"Value with key [{key}] not found on Group [{self.group_name}], "
                 )
         return rpc.remote(holder, _rpc_get_paired_value, args=(self.group_name, key))
 
@@ -870,7 +864,7 @@ class RpcGroup:
         if get_cur_name() == self.group_members[0]:
             while True:
                 all_entered = all(
-                    self.registered_sync("_rpc_entered_barrier_{}".format(m))
+                    self.registered_sync(f"_rpc_entered_barrier_{m}")
                     for m in self.group_members
                 )
                 if not all_entered:
@@ -878,7 +872,7 @@ class RpcGroup:
                 else:
                     break
             for m in self.group_members:
-                self.registered_sync("_rpc_exit_barrier_{}".format(m))
+                self.registered_sync(f"_rpc_exit_barrier_{m}")
         else:
             self._barrier_event.wait()
 
@@ -946,9 +940,7 @@ class RpcGroup:
             )
             if not status:
                 raise KeyError(
-                    "Service with key [{}] not found on Group [{}], ".format(
-                        key, self.group_name
-                    )
+                    f"Service with key [{key}] not found on Group [{self.group_name}], "
                 )
         return rpc_method(
             holder, _rpc_call_service, args=(self.group_name, key, args, kwargs)

--- a/machin/parallel/distributed/world.py
+++ b/machin/parallel/distributed/world.py
@@ -94,9 +94,7 @@ def _rpc_call_service(group_name, key, args, kwargs):  # pragma: no cover
             _rpc_unset_lut_entry,
             args=(group_name, key, get_cur_name(), LUTType.SERVICE),
         )
-        raise KeyError(
-            "Group [{}], not found on Process [{}]".format(group_name, get_cur_name())
-        )
+        raise KeyError(f"Group [{group_name}], not found on Process [{get_cur_name()}]")
     lut = WORLD.groups[group_name].group_service_lut
 
     if key in lut:
@@ -131,9 +129,7 @@ def _rpc_get_paired_value(group_name, key):  # pragma: no cover
             _rpc_unset_lut_entry,
             args=(group_name, key, get_cur_name(), LUTType.VALUE),
         )
-        raise KeyError(
-            "Group [{}], not found on Process [{}]".format(group_name, get_cur_name())
-        )
+        raise KeyError(f"Group [{group_name}], not found on Process [{get_cur_name()}]")
 
     paired_map = WORLD.groups[group_name].group_value_lut
 
@@ -229,10 +225,10 @@ class RpcException(Exception):  # pragma: no cover
     def __init__(self, msg):
         if isinstance(msg, str):
             # used by rpc when reraising the exception on the caller side
-            super(RpcException, self).__init__(msg)
+            super().__init__(msg)
         else:
             tb = ExceptionWithTraceback(msg).tb
-            super(RpcException, self).__init__(tb)
+            super().__init__(tb)
 
 
 @_world_singleton
@@ -583,12 +579,10 @@ class RpcGroup:
         self._barrier_status = False
         if first_create and self.is_member(get_cur_name()):
             self.register(
-                "_rpc_entered_barrier_{}".format(get_cur_name()),
+                f"_rpc_entered_barrier_{get_cur_name()}",
                 self._rpc_entered_barrier,
             )
-            self.register(
-                "_rpc_exit_barrier_{}".format(get_cur_name()), self._rpc_exit_barrier
-            )
+            self.register(f"_rpc_exit_barrier_{get_cur_name()}", self._rpc_exit_barrier)
 
     @_copy_doc(rpc.rpc_sync)
     def rpc_sync(self, to: str, func: Callable, timeout=-1, args=(), kwargs=None):

--- a/machin/parallel/event.py
+++ b/machin/parallel/event.py
@@ -25,7 +25,7 @@ class MultiEvent(Event):
     # can only be used with Event from threading and not from multiprocessing
     def __init__(self, *events):
         global _lock
-        super(MultiEvent, self).__init__()
+        super().__init__()
 
         with _lock:
             self.is_leaf = all([type(e) == Event for e in events])

--- a/machin/parallel/exception.py
+++ b/machin/parallel/exception.py
@@ -37,7 +37,7 @@ class ExceptionWithTraceback:  # pragma: no cover
         tb = traceback.format_exception(type(exc), exc, tb)
         tb = "".join(tb)
         self.exc = exc
-        self.tb = '\n"""\n%s"""' % tb
+        self.tb = f'\n"""\n{tb}"""'
 
     def __reduce__(self):
         # Used by pickler

--- a/machin/parallel/pickle.py
+++ b/machin/parallel/pickle.py
@@ -59,7 +59,7 @@ class Pickler(DillPickler):
     """
 
     def __init__(self, file, recurse=False, copy_tensor=False):
-        super(Pickler, self).__init__(file, byref=False, recurse=recurse)
+        super().__init__(file, byref=False, recurse=recurse)
         self.dispatch_table = copyreg.dispatch_table.copy()
         if not copy_tensor:
             # register the reduction methods provided by pytorch

--- a/machin/parallel/pool.py
+++ b/machin/parallel/pool.py
@@ -115,7 +115,7 @@ class Pool(pool.Pool):
             if share_method == "cpu":
                 context = get_context("fork")
 
-        super(Pool, self).__init__(
+        super().__init__(
             processes=processes,
             initializer=initializer,
             initargs=initargs,
@@ -402,7 +402,7 @@ class CtxPool(Pool):
         else:
             worker_contexts = [None] * processes
 
-        super(CtxPool, self).__init__(
+        super().__init__(
             processes=processes,
             initializer=self._init_with_context,
             initargs=(worker_contexts, initializer) + initargs,
@@ -496,7 +496,7 @@ class CtxThreadPool(ThreadPool):
         else:
             worker_contexts = [None] * processes
 
-        super(CtxThreadPool, self).__init__(
+        super().__init__(
             processes=processes,
             initializer=self._init_with_context,
             initargs=(worker_contexts, initializer) + initargs,
@@ -505,50 +505,38 @@ class CtxThreadPool(ThreadPool):
     def apply(self, func, args=(), kwds=None):
         if kwds is None:
             kwds = {}
-        return (
-            super(CtxThreadPool, self)
-            .apply_async(self._wrap_func(func), args, kwds)
-            .get()
-        )
+        return super().apply_async(self._wrap_func(func), args, kwds).get()
 
     def apply_async(self, func, args=(), kwds=None, callback=None, error_callback=None):
         if kwds is None:
             kwds = {}
-        return super(CtxThreadPool, self).apply_async(
+        return super().apply_async(
             self._wrap_func(func), args, kwds, callback, error_callback
         )
 
     def map(self, func, iterable, chunksize=None):
-        return super(CtxThreadPool, self).map(
-            self._wrap_func(func), iterable, chunksize
-        )
+        return super().map(self._wrap_func(func), iterable, chunksize)
 
     def map_async(
         self, func, iterable, chunksize=None, callback=None, error_callback=None
     ):
-        return super(CtxThreadPool, self).map_async(
+        return super().map_async(
             self._wrap_func(func), iterable, chunksize, callback, error_callback
         )
 
     def imap(self, func, iterable, chunksize=1):
-        return super(CtxThreadPool, self).imap(
-            self._wrap_func(func), iterable, chunksize
-        )
+        return super().imap(self._wrap_func(func), iterable, chunksize)
 
     def imap_unordered(self, func, iterable, chunksize=1):
-        return super(CtxThreadPool, self).imap_unordered(
-            self._wrap_func(func), iterable, chunksize
-        )
+        return super().imap_unordered(self._wrap_func(func), iterable, chunksize)
 
     def starmap(self, func, iterable, chunksize=None):
-        return super(CtxThreadPool, self).starmap(
-            self._wrap_func(func), iterable, chunksize
-        )
+        return super().starmap(self._wrap_func(func), iterable, chunksize)
 
     def starmap_async(
         self, func, iterable, chunksize=None, callback=None, error_callback=None
     ):
-        return super(CtxThreadPool, self).starmap_async(
+        return super().starmap_async(
             self._wrap_func(func), iterable, chunksize, callback, error_callback
         )
 

--- a/machin/parallel/pool.py
+++ b/machin/parallel/pool.py
@@ -111,7 +111,7 @@ class Pool(pool.Pool):
         context = get_context("spawn")
         if not is_copy_tensor:
             if share_method not in ("cpu", "cuda"):
-                raise RuntimeError('Invalid share method: "{}"'.format(share_method))
+                raise RuntimeError(f'Invalid share method: "{share_method}"')
             if share_method == "cpu":
                 context = get_context("fork")
 

--- a/machin/parallel/process.py
+++ b/machin/parallel/process.py
@@ -22,7 +22,7 @@ class Process(BaseProcess):
         daemon=None,
     ):
         self._exc_pipe = Pipe()
-        super(Process, self).__init__(
+        super().__init__(
             group=group,
             target=target,
             name=name,
@@ -64,7 +64,7 @@ class Process(BaseProcess):
     def run(self):
         exc = []
         try:
-            super(Process, self).run()
+            super().run()
         except BaseException as e:
             exc.append(e)
         finally:

--- a/machin/parallel/process.py
+++ b/machin/parallel/process.py
@@ -19,7 +19,7 @@ class Process(BaseProcess):
         cleaner=None,
         ctx=_default_context,
         *,
-        daemon=None
+        daemon=None,
     ):
         self._exc_pipe = Pipe()
         super(Process, self).__init__(
@@ -58,7 +58,7 @@ class Process(BaseProcess):
             tb = exc.__traceback__
             tb = traceback.format_exception(type(exc), exc, tb)
             tb = "".join(tb)
-            all_tb = all_tb + "\nException {}:\n{}".format(i, tb)
+            all_tb = all_tb + f"\nException {i}:\n{tb}"
         return all_tb
 
     def run(self):

--- a/machin/parallel/queue.py
+++ b/machin/parallel/queue.py
@@ -6,7 +6,7 @@ import sys
 from .pickle import dumps, loads
 
 
-class ConnectionWrapper(object):  # pragma: no cover
+class ConnectionWrapper:  # pragma: no cover
     """
     This simple wrapper provides timeout function for sending
     bytes on ``Connection``.
@@ -41,7 +41,7 @@ class ConnectionWrapper(object):  # pragma: no cover
         )
 
 
-class SimpleQueue(object):  # pragma: no cover
+class SimpleQueue:  # pragma: no cover
     """
     A simple single direction queue for inter-process communications.
     There could be multiple receivers and multiple senders on each side.
@@ -168,7 +168,7 @@ class SimpleQueue(object):  # pragma: no cover
         self.close()
 
 
-class SimpleP2PQueue(object):  # pragma: no cover
+class SimpleP2PQueue:  # pragma: no cover
     """
     A simple single direction queue for inter-process P2P communications.
     Each end only have one process.
@@ -244,7 +244,7 @@ class SimpleP2PQueue(object):  # pragma: no cover
         self.close()
 
 
-class MultiP2PQueue(object):
+class MultiP2PQueue:
     """
     P2P queue which connects pool result manager and worker processes directly,
     with no lock.

--- a/machin/parallel/server/ordered_server.py
+++ b/machin/parallel/server/ordered_server.py
@@ -68,7 +68,7 @@ class OrderedServerSimple(OrderedServerBase):
         return self.group.registered_sync(self._pull_service, args=(key, version))
 
 
-class OrderedServerSimpleImpl(object):
+class OrderedServerSimpleImpl:
     """
     A simple key-value server, with strict ordered update
     """

--- a/machin/parallel/server/param_server.py
+++ b/machin/parallel/server/param_server.py
@@ -167,9 +167,7 @@ class PushPullGradServer:
         grad_dict = {}
         for k, v in model.named_parameters():
             if not hasattr(v, "grad") or not t.is_tensor(v.grad):  # pragma: no cover
-                raise RuntimeError(
-                    "Parameter {} doesn't have gradient " "to push!".format(k)
-                )
+                raise RuntimeError(f"Parameter {k} doesn't have gradient to push!")
             grad_dict[k] = deepcopy(v.grad).to("cpu")
         self.group.registered_sync(
             choice(self.secondary_services),
@@ -393,7 +391,7 @@ class PushPullGradServerImpl:
             self.work_event.set()
             self.work_event.clear()
         else:  # pragma: no cover
-            raise ValueError("Unknown push level: {}".format(level))
+            raise ValueError(f"Unknown push level: {level}")
 
     def _task_reduce_grad(self):
         while True:

--- a/machin/parallel/thread.py
+++ b/machin/parallel/thread.py
@@ -20,7 +20,7 @@ class Thread(threading.Thread):
         kwargs={},
         cleaner=None,
         *,
-        daemon=None
+        daemon=None,
     ):
         threading.Thread.__init__(
             self,
@@ -53,7 +53,7 @@ class Thread(threading.Thread):
             tb = exc.__traceback__
             tb = traceback.format_exception(type(exc), exc, tb)
             tb = "".join(tb)
-            all_tb = all_tb + "\nException {}:\n{}".format(i, tb)
+            all_tb = all_tb + f"\nException {i}:\n{tb}"
         return all_tb
 
     def run(self):

--- a/machin/parallel/thread.py
+++ b/machin/parallel/thread.py
@@ -59,7 +59,7 @@ class Thread(threading.Thread):
     def run(self):
         exc = []
         try:
-            super(Thread, self).run()
+            super().run()
         except BaseException as e:
             exc.append(e)
         finally:

--- a/machin/utils/checker.py
+++ b/machin/utils/checker.py
@@ -44,7 +44,7 @@ def check_nan(tensor: t.Tensor, name=""):
         ``RuntimeError`` if tensor has any ``nan`` element.
     """
     if t.any(t.isnan(tensor)):
-        raise CheckError("Tensor {} contains nan!".format(name))
+        raise CheckError(f"Tensor {name} contains nan!")
 
 
 def _add_input_check_hook(
@@ -187,7 +187,7 @@ def p_chk_nan(
     """
     Check whether there is any nan element in the parameter.
     """
-    check_nan(param_val, param_name + "(backward_count={})".format(counter.get()))
+    check_nan(param_val, param_name + f"(backward_count={counter.get()})")
 
 
 def p_chk_range(

--- a/machin/utils/conf.py
+++ b/machin/utils/conf.py
@@ -12,7 +12,7 @@ class Config(Object):
     """
 
     def __init__(self, **configs):
-        super(Config, self).__init__(configs)
+        super().__init__(configs)
 
     def get(self, key, default=None):
         if key in self:
@@ -100,7 +100,7 @@ def load_config_file(json_file: str, merge_conf: Config = None) -> Config:
         configuration
     """
     # parse the configurations from the config json file provided
-    with open(json_file, "r") as config_file:
+    with open(json_file) as config_file:
         config_dict = json.load(config_file)
 
     return merge_config((Config() if merge_conf is None else merge_conf), config_dict)

--- a/machin/utils/helper_classes.py
+++ b/machin/utils/helper_classes.py
@@ -146,7 +146,7 @@ class Object:
         # not return a None value because self.attr(item) will return None.
         if isinstance(item, str) and item[:2] == item[-2:] == "__":
             # skip non-existing special method lookups
-            raise AttributeError("Failed to find attribute: {}".format(item))
+            raise AttributeError(f"Failed to find attribute: {item}")
         return self.attr(item)
 
     def __getitem__(self, item):
@@ -160,7 +160,7 @@ class Object:
             and key not in self.__dir__()
         ):
             if key in self.const_attrs:
-                raise RuntimeError("{} is const.".format(key))
+                raise RuntimeError(f"{key} is const.")
             self.attr(key, value, change=True)
         elif key == "call":
             super(Object, self).__setattr__(key, value)

--- a/machin/utils/helper_classes.py
+++ b/machin/utils/helper_classes.py
@@ -125,8 +125,8 @@ class Object:
             data = {}
         if const_attrs is None:
             const_attrs = set()
-        super(Object, self).__setattr__("const_attrs", const_attrs)
-        super(Object, self).__setattr__("data", data)
+        super().__setattr__("const_attrs", const_attrs)
+        super().__setattr__("data", data)
 
     def __call__(self, *args, **kwargs):
         return self.call(*args, **kwargs)
@@ -163,10 +163,10 @@ class Object:
                 raise RuntimeError(f"{key} is const.")
             self.attr(key, value, change=True)
         elif key == "call":
-            super(Object, self).__setattr__(key, value)
+            super().__setattr__(key, value)
         elif key == "data":
             if isinstance(value, dict):
-                super(Object, self).__setattr__(key, value)
+                super().__setattr__(key, value)
             else:
                 raise ValueError("The data attribute must be a dictionary.")
         else:

--- a/machin/utils/learning_rate.py
+++ b/machin/utils/learning_rate.py
@@ -30,10 +30,10 @@ def gen_learning_rate_func(lr_map: List[Tuple[int, float]], logger: Logger = Non
         for i in range(len(lr_map) - 1):
             if lr_map[i][0] <= step < lr_map[i + 1][0]:
                 if logger is not None:
-                    logger.info("Current learning rate:{}".format(lr_map[i][1]))
+                    logger.info(f"Current learning rate:{lr_map[i][1]}")
                 return lr_map[i][1]
         if logger is not None:
-            logger.info("Current learning rate:{}".format(lr_map[-1][1]))
+            logger.info(f"Current learning rate:{lr_map[-1][1]}")
         return lr_map[-1][1]
 
     return learning_rate_func

--- a/machin/utils/logging.py
+++ b/machin/utils/logging.py
@@ -8,7 +8,7 @@ import colorlog
 from logging import INFO
 
 
-class FakeLogger(object):
+class FakeLogger:
     def setLevel(self, level):
         pass
 

--- a/machin/utils/prepare.py
+++ b/machin/utils/prepare.py
@@ -86,11 +86,11 @@ def prep_load_model(
     if version is not None:
         is_version_found = [version in version_map[name] for name in model_map.keys()]
         if all(is_version_found):
-            logger.info("Specified version found, using version: {}".format(version))
+            logger.info(f"Specified version found, using version: {version}")
             for net_name, net in model_map.items():
                 net = net  # type: nn.Module
                 state_dict = t.load(
-                    join(model_dir, "{}_{}.pt".format(net_name, version)),
+                    join(model_dir, f"{net_name}_{version}.pt"),
                     map_location="cpu",
                 ).state_dict()
                 prep_load_state_dict(net, state_dict)
@@ -99,9 +99,7 @@ def prep_load_model(
             for ivf, net_name in zip(is_version_found, model_map.keys()):
                 if not ivf:
                     logger.warning(
-                        "Specified version {} for network {} is invalid".format(
-                            version, net_name
-                        )
+                        f"Specified version {version} for network {net_name} is invalid"
                     )
 
     logger.info("Begin auto find")
@@ -113,9 +111,9 @@ def prep_load_model(
         else:
             return
     version = max(common)
-    logger.info("Using version: {}".format(version))
+    logger.info(f"Using version: {version}")
     for net_name, net in model_map.items():
         state_dict = t.load(
-            join(model_dir, "{}_{}.pt".format(net_name, version)), map_location="cpu"
+            join(model_dir, f"{net_name}_{version}.pt"), map_location="cpu"
         ).state_dict()
         prep_load_state_dict(net, state_dict)

--- a/machin/utils/save_env.py
+++ b/machin/utils/save_env.py
@@ -178,7 +178,7 @@ class SaveEnv:
                 diff_time = current_time - time
                 if diff_time > diff_threshold:
                     rm_path = join(self.env_root, file)
-                    default_logger.info("Removing trial directory: {}".format(rm_path))
+                    default_logger.info(f"Removing trial directory: {rm_path}")
                     shutil.rmtree(rm_path)
 
     def _prep_dirs(self):

--- a/test/auto/_pl_plugin_runner.py
+++ b/test/auto/_pl_plugin_runner.py
@@ -13,7 +13,7 @@ import machin.auto
 
 class NNModule(nn.Module):
     def __init__(self):
-        super(NNModule, self).__init__()
+        super().__init__()
         self.fc1 = nn.Linear(10, 10)
 
     def forward(self, x):
@@ -22,7 +22,7 @@ class NNModule(nn.Module):
 
 class ParallelModule(pl.LightningModule):
     def __init__(self):
-        super(ParallelModule, self).__init__()
+        super().__init__()
         self.nn_model = NNModule()
 
     def train_dataloader(self):

--- a/test/auto/env/test_openai_gym.py
+++ b/test/auto/env/test_openai_gym.py
@@ -293,7 +293,7 @@ class InspectCallback(Callback):
             if "total_reward" in log:
                 self.max_total_reward = max(log["total_reward"], self.max_total_reward)
                 default_logger.info(
-                    "Current max total reward={:.2f}.".format(self.max_total_reward)
+                    f"Current max total reward={self.max_total_reward:.2f}."
                 )
                 if self.max_total_reward >= 190:
                     trainer.should_stop = True

--- a/test/auto/env/test_openai_gym.py
+++ b/test/auto/env/test_openai_gym.py
@@ -24,7 +24,7 @@ import torch.nn.functional as F
 
 class QNet(nn.Module):
     def __init__(self, state_dim, action_num):
-        super(QNet, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -38,7 +38,7 @@ class QNet(nn.Module):
 
 class A2CActorCont(nn.Module):
     def __init__(self, state_dim, action_dim, action_range):
-        super(A2CActorCont, self).__init__()
+        super().__init__()
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
         self.mu_head = nn.Linear(16, action_dim)
@@ -60,7 +60,7 @@ class A2CActorCont(nn.Module):
 
 class A2CActorDisc(nn.Module):
     def __init__(self, state_dim, action_num):
-        super(A2CActorDisc, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -79,7 +79,7 @@ class A2CActorDisc(nn.Module):
 
 class A2CCritic(nn.Module):
     def __init__(self, state_dim):
-        super(A2CCritic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -94,7 +94,7 @@ class A2CCritic(nn.Module):
 
 class DDPGActorCont(nn.Module):
     def __init__(self, state_dim, action_dim, action_range):
-        super(DDPGActorCont, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -110,7 +110,7 @@ class DDPGActorCont(nn.Module):
 
 class DDPGActorDisc(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(DDPGActorDisc, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -125,7 +125,7 @@ class DDPGActorDisc(nn.Module):
 
 class DDPGCritic(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(DDPGCritic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim + action_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -149,7 +149,7 @@ class TestRLGymDiscActDataset:
         assert t.is_tensor(result.observations[0]["next_state"]["state"])
         assert isinstance(result.observations[0]["reward"], float)
         assert isinstance(result.observations[0]["terminal"], bool)
-        log_keys = set([k for log_dict in result.logs for k in log_dict])
+        log_keys = {k for log_dict in result.logs for k in log_dict}
         assert log_keys.issuperset({"video", "total_reward"})
 
     # Only test single node, most representative algorithms
@@ -205,7 +205,7 @@ class TestRLGymContActDataset:
         assert t.is_tensor(result.observations[0]["next_state"]["state"])
         assert isinstance(result.observations[0]["reward"], float)
         assert isinstance(result.observations[0]["terminal"], bool)
-        log_keys = set([k for log_dict in result.logs for k in log_dict])
+        log_keys = {k for log_dict in result.logs for k in log_dict}
         assert log_keys.issuperset({"video", "total_reward"})
 
     # Only test single node, most representative algorithms

--- a/test/auto/test_dataset.py
+++ b/test/auto/test_dataset.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 
 class QNet(nn.Module):
     def __init__(self, state_dim, action_num):
-        super(QNet, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)

--- a/test/auto/test_launcher.py
+++ b/test/auto/test_launcher.py
@@ -1,7 +1,7 @@
 from machin.frame.algorithms import DQN
 from machin.auto.launcher import Launcher
 from machin.auto.dataset import RLDataset, DatasetResult
-import mock
+from unittest import mock
 import pytest
 import torch as t
 import torch.nn as nn
@@ -10,7 +10,7 @@ import pytorch_lightning as pl
 
 class QNet(nn.Module):
     def __init__(self, state_dim, action_num):
-        super(QNet, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)

--- a/test/auto/test_pl_plugin.py
+++ b/test/auto/test_pl_plugin.py
@@ -24,15 +24,11 @@ class TestDDPPlugin:
             process_0.kill()
             pytest.fail("Timeout on waiting for the DDPPlugin script to end.")
         elif process_0.returncode != 0:
-            pytest.fail(
-                "DDPPlugin script returned code {}.".format(process_0.returncode)
-            )
+            pytest.fail(f"DDPPlugin script returned code {process_0.returncode}.")
         else:
             with open(test_save_path, "rb") as f:
                 flags = pickle.load(f)
-                assert flags == [True], "Not properly_inited, flags are: {}".format(
-                    flags
-                )
+                assert flags == [True], f"Not properly_inited, flags are: {flags}"
 
 
 class TestDDPSpawnPlugin:
@@ -53,12 +49,8 @@ class TestDDPSpawnPlugin:
             process_0.kill()
             pytest.fail("Timeout on waiting for the DDPSpawnPlugin " "script to end.")
         elif process_0.returncode != 0:
-            pytest.fail(
-                "DDPSpawnPlugin script returned code {}.".format(process_0.returncode)
-            )
+            pytest.fail(f"DDPSpawnPlugin script returned code {process_0.returncode}.")
         else:
             with open(test_save_path, "rb") as f:
                 flags = pickle.load(f)
-                assert flags == [True], "Not properly_inited, flags are: {}".format(
-                    flags
-                )
+                assert flags == [True], f"Not properly_inited, flags are: {flags}"

--- a/test/env/wrappers/test_openai_gym.py
+++ b/test/env/wrappers/test_openai_gym.py
@@ -92,7 +92,7 @@ def envs():
     return all_envs
 
 
-class TestParallelWrapperDummy(object):
+class TestParallelWrapperDummy:
     ########################################################################
     # Test for ParallelWrapperDummy.reset
     ########################################################################
@@ -215,7 +215,7 @@ class TestParallelWrapperDummy(object):
         dummy_wrapper.close()
 
 
-class TestParallelWrapperSubProc(object):
+class TestParallelWrapperSubProc:
     ########################################################################
     # Test for ParallelWrapperSubProc.reset
     ########################################################################

--- a/test/env/wrappers/test_openai_gym.py
+++ b/test/env/wrappers/test_openai_gym.py
@@ -86,7 +86,7 @@ def envs():
     # Create environments.
     for env_name, env_version in env_map.items():
         env_name = env_name + "-v" + str(env_version)
-        lg.info("OpenAI gym {} added".format(env_name))
+        lg.info(f"OpenAI gym {env_name} added")
         all_envs.append([lambda *_: gym.make(env_name) for _ in range(ENV_NUM)])
     lg.info("{} OpenAI gym environments to be tested.".format(len(all_envs)))
     return all_envs

--- a/test/frame/algorithms/test_a2c.py
+++ b/test/frame/algorithms/test_a2c.py
@@ -19,7 +19,7 @@ from test.util_fixtures import *
 
 class Actor(nn.Module):
     def __init__(self, state_dim, action_num):
-        super(Actor, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -38,7 +38,7 @@ class Actor(nn.Module):
 
 class Critic(nn.Module):
     def __init__(self, state_dim):
-        super(Critic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -51,7 +51,7 @@ class Critic(nn.Module):
         return v
 
 
-class TestA2C(object):
+class TestA2C:
     # configs and definitions
     @pytest.fixture(scope="class")
     def train_config(self):

--- a/test/frame/algorithms/test_a2c.py
+++ b/test/frame/algorithms/test_a2c.py
@@ -353,9 +353,7 @@ class TestA2C(object):
             step.reset()
             terminal = False
 
-            logger.info(
-                "Episode {} total reward={:.2f}".format(episode, smoother.value)
-            )
+            logger.info(f"Episode {episode} total reward={smoother.value:.2f}")
 
             if smoother.value > c.solved_reward:
                 reward_fulfilled.count()

--- a/test/frame/algorithms/test_a3c.py
+++ b/test/frame/algorithms/test_a3c.py
@@ -18,7 +18,7 @@ from test.util_fixtures import *
 
 class Actor(nn.Module):
     def __init__(self, state_dim, action_num):
-        super(Actor, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -37,7 +37,7 @@ class Actor(nn.Module):
 
 class Critic(nn.Module):
     def __init__(self, state_dim):
-        super(Critic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -50,7 +50,7 @@ class Critic(nn.Module):
         return v
 
 
-class TestA3C(object):
+class TestA3C:
     # configs and definitions
     disable_view_window()
     c = Config()

--- a/test/frame/algorithms/test_a3c.py
+++ b/test/frame/algorithms/test_a3c.py
@@ -264,7 +264,7 @@ class TestA3C(object):
 
         env = c.env
         # for cpu usage viewing
-        default_logger.info("{}, pid {}".format(rank, os.getpid()))
+        default_logger.info(f"{rank}, pid {os.getpid()}")
         while episode < c.max_episodes:
             episode.count()
 
@@ -303,9 +303,7 @@ class TestA3C(object):
             terminal = False
 
             default_logger.info(
-                "Process {} Episode {} total reward={:.2f}".format(
-                    rank, episode, smoother.value
-                )
+                f"Process {rank} Episode {episode} total reward={smoother.value:.2f}"
             )
 
             if smoother.value > c.solved_reward:

--- a/test/frame/algorithms/test_apex.py
+++ b/test/frame/algorithms/test_apex.py
@@ -264,7 +264,7 @@ class TestDQNApex(object):
         env = c.env
         world = get_world()
         all_group = world.create_rpc_group("all", ["0", "1", "2"])
-        all_group.pair("{}_running".format(rank), True)
+        all_group.pair(f"{rank}_running", True)
 
         if rank in (0, 1):
             while episode < c.max_episodes:
@@ -313,7 +313,7 @@ class TestDQNApex(object):
                     if reward_fulfilled >= c.solved_repeat:
                         default_logger.info("Environment solved!")
 
-                        all_group.unpair("{}_running".format(rank))
+                        all_group.unpair(f"{rank}_running")
                         while all_group.is_paired("0_running") or all_group.is_paired(
                             "1_running"
                         ):
@@ -584,8 +584,8 @@ class TestDDPGApex(object):
         env = c.env
         world = get_world()
         all_group = world.create_rpc_group("all", ["0", "1", "2"])
-        all_group.pair("{}_running".format(rank), True)
-        default_logger.info("{}, pid {}".format(rank, os.getpid()))
+        all_group.pair(f"{rank}_running", True)
+        default_logger.info(f"{rank}, pid {os.getpid()}")
         if rank == 0:
             all_group.pair("episode", episode)
 
@@ -638,7 +638,7 @@ class TestDDPGApex(object):
                     if reward_fulfilled >= c.solved_repeat:
                         default_logger.info("Environment solved!")
 
-                        all_group.unpair("{}_running".format(rank))
+                        all_group.unpair(f"{rank}_running")
                         while all_group.is_paired("0_running") or all_group.is_paired(
                             "1_running"
                         ):

--- a/test/frame/algorithms/test_apex.py
+++ b/test/frame/algorithms/test_apex.py
@@ -17,7 +17,7 @@ from test.util_fixtures import *
 
 class QNet(nn.Module):
     def __init__(self, state_dim, action_num):
-        super(QNet, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -31,7 +31,7 @@ class QNet(nn.Module):
 
 class Actor(nn.Module):
     def __init__(self, state_dim, action_dim, action_range):
-        super(Actor, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -47,7 +47,7 @@ class Actor(nn.Module):
 
 class ActorDiscrete(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(ActorDiscrete, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -62,7 +62,7 @@ class ActorDiscrete(nn.Module):
 
 class Critic(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(Critic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim + action_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -76,7 +76,7 @@ class Critic(nn.Module):
         return q
 
 
-class TestDQNApex(object):
+class TestDQNApex:
     # configs and definitions
     disable_view_window()
     c = Config()
@@ -335,7 +335,7 @@ class TestDQNApex(object):
         raise RuntimeError("DQN-Apex Training failed.")
 
 
-class TestDDPGApex(object):
+class TestDDPGApex:
     # configs and definitions
     disable_view_window()
     c = Config()

--- a/test/frame/algorithms/test_ars.py
+++ b/test/frame/algorithms/test_ars.py
@@ -17,7 +17,7 @@ from test.util_run_multi import *
 from test.util_fixtures import *
 
 
-class TestRunningStat(object):
+class TestRunningStat:
     @pytest.mark.parametrize("shape", ((), (3,), (3, 4)))
     def test_push(self, shape):
         vals = []
@@ -68,7 +68,7 @@ class TestRunningStat(object):
 
 class ActorDiscrete(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(ActorDiscrete, self).__init__()
+        super().__init__()
         self.fc = nn.Linear(state_dim, action_dim, bias=False)
 
     def forward(self, state):
@@ -76,7 +76,7 @@ class ActorDiscrete(nn.Module):
         return a
 
 
-class TestARS(object):
+class TestARS:
     # configs and definitions
     # Cartpole-v0 can be solved:
     # within 200 episodes, using single layer Actor

--- a/test/frame/algorithms/test_ars.py
+++ b/test/frame/algorithms/test_ars.py
@@ -274,7 +274,7 @@ class TestARS(object):
 
         env = c.env
         # for cpu usage viewing
-        default_logger.info("{}, pid {}".format(rank, os.getpid()))
+        default_logger.info(f"{rank}, pid {os.getpid()}")
         while episode < c.max_episodes:
             episode.count()
 
@@ -301,9 +301,7 @@ class TestARS(object):
             ars.update()
             smoother.update(all_reward / len(ars.get_actor_types()))
             default_logger.info(
-                "Process {} Episode {} total reward={:.2f}".format(
-                    rank, episode, smoother.value
-                )
+                f"Process {rank} Episode {episode} total reward={smoother.value:.2f}"
             )
 
             if smoother.value > c.solved_reward:

--- a/test/frame/algorithms/test_ddpg.py
+++ b/test/frame/algorithms/test_ddpg.py
@@ -460,9 +460,7 @@ class TestDDPG(object):
 
             if episode.get() % c.noise_interval != 0:
                 # only log result without noise
-                logger.info(
-                    "Episode {} total reward={:.2f}".format(episode, smoother.value)
-                )
+                logger.info(f"Episode {episode} total reward={smoother.value:.2f}")
 
             if smoother.value > c.solved_reward:
                 reward_fulfilled.count()

--- a/test/frame/algorithms/test_ddpg.py
+++ b/test/frame/algorithms/test_ddpg.py
@@ -18,7 +18,7 @@ from test.util_fixtures import *
 
 class Actor(nn.Module):
     def __init__(self, state_dim, action_dim, action_range):
-        super(Actor, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -34,7 +34,7 @@ class Actor(nn.Module):
 
 class ActorDiscrete(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(ActorDiscrete, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -49,7 +49,7 @@ class ActorDiscrete(nn.Module):
 
 class Critic(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(Critic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim + action_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -63,7 +63,7 @@ class Critic(nn.Module):
         return q
 
 
-class TestDDPG(object):
+class TestDDPG:
     # configs and definitions
     @pytest.fixture(scope="class")
     def train_config(self):

--- a/test/frame/algorithms/test_ddpg_per.py
+++ b/test/frame/algorithms/test_ddpg_per.py
@@ -16,7 +16,7 @@ from test.util_fixtures import *
 
 class Actor(nn.Module):
     def __init__(self, state_dim, action_dim, action_range):
-        super(Actor, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -32,7 +32,7 @@ class Actor(nn.Module):
 
 class Critic(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(Critic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim + action_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -46,7 +46,7 @@ class Critic(nn.Module):
         return q
 
 
-class TestDDPGPer(object):
+class TestDDPGPer:
     # configs and definitions
     @pytest.fixture(scope="class")
     def train_config(self):

--- a/test/frame/algorithms/test_ddpg_per.py
+++ b/test/frame/algorithms/test_ddpg_per.py
@@ -341,9 +341,7 @@ class TestDDPGPer(object):
 
             if episode.get() % c.noise_interval != 0:
                 # only log result without noise
-                logger.info(
-                    "Episode {} total reward={:.2f}".format(episode, smoother.value)
-                )
+                logger.info(f"Episode {episode} total reward={smoother.value:.2f}")
 
             if smoother.value > c.solved_reward:
                 reward_fulfilled.count()

--- a/test/frame/algorithms/test_dqn.py
+++ b/test/frame/algorithms/test_dqn.py
@@ -18,7 +18,7 @@ from test.util_fixtures import *
 
 class QNet(nn.Module):
     def __init__(self, state_dim, action_num):
-        super(QNet, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -30,7 +30,7 @@ class QNet(nn.Module):
         return self.fc3(a)
 
 
-class TestDQN(object):
+class TestDQN:
     # configs and definitions
     @pytest.fixture(scope="class")
     def train_config(self):

--- a/test/frame/algorithms/test_dqn.py
+++ b/test/frame/algorithms/test_dqn.py
@@ -386,9 +386,7 @@ class TestDQN(object):
             step.reset()
             terminal = False
 
-            logger.info(
-                "Episode {} total reward={:.2f}".format(episode, smoother.value)
-            )
+            logger.info(f"Episode {episode} total reward={smoother.value:.2f}")
 
             if smoother.value > c.solved_reward:
                 reward_fulfilled.count()

--- a/test/frame/algorithms/test_dqn_per.py
+++ b/test/frame/algorithms/test_dqn_per.py
@@ -275,9 +275,7 @@ class TestDQNPer(object):
             step.reset()
             terminal = False
 
-            logger.info(
-                "Episode {} total reward={:.2f}".format(episode, smoother.value)
-            )
+            logger.info(f"Episode {episode} total reward={smoother.value:.2f}")
 
             if smoother.value > c.solved_reward:
                 reward_fulfilled.count()

--- a/test/frame/algorithms/test_dqn_per.py
+++ b/test/frame/algorithms/test_dqn_per.py
@@ -16,7 +16,7 @@ from test.util_fixtures import *
 
 class QNet(nn.Module):
     def __init__(self, state_dim, action_num):
-        super(QNet, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -28,7 +28,7 @@ class QNet(nn.Module):
         return self.fc3(a)
 
 
-class TestDQNPer(object):
+class TestDQNPer:
     # configs and definitions
     @pytest.fixture(scope="class")
     def train_config(self):

--- a/test/frame/algorithms/test_hddpg.py
+++ b/test/frame/algorithms/test_hddpg.py
@@ -18,7 +18,7 @@ from test.util_fixtures import *
 
 class Actor(nn.Module):
     def __init__(self, state_dim, action_dim, action_range):
-        super(Actor, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -34,7 +34,7 @@ class Actor(nn.Module):
 
 class Critic(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(Critic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim + action_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -48,7 +48,7 @@ class Critic(nn.Module):
         return q
 
 
-class TestHDDPG(object):
+class TestHDDPG:
     # configs and definitions
     @pytest.fixture(scope="class")
     def train_config(self):

--- a/test/frame/algorithms/test_hddpg.py
+++ b/test/frame/algorithms/test_hddpg.py
@@ -304,9 +304,7 @@ class TestHDDPG(object):
 
             if episode.get() % c.noise_interval != 0:
                 # only log result without noise
-                logger.info(
-                    "Episode {} total reward={:.2f}".format(episode, smoother.value)
-                )
+                logger.info(f"Episode {episode} total reward={smoother.value:.2f}")
 
             if smoother.value > c.solved_reward:
                 reward_fulfilled.count()

--- a/test/frame/algorithms/test_impala.py
+++ b/test/frame/algorithms/test_impala.py
@@ -20,7 +20,7 @@ from test.util_fixtures import *
 
 class Actor(nn.Module):
     def __init__(self, state_dim, action_num):
-        super(Actor, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -39,7 +39,7 @@ class Actor(nn.Module):
 
 class Critic(nn.Module):
     def __init__(self, state_dim):
-        super(Critic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -52,7 +52,7 @@ class Critic(nn.Module):
         return v
 
 
-class TestIMPALA(object):
+class TestIMPALA:
     # configs and definitions
     disable_view_window()
     c = Config()

--- a/test/frame/algorithms/test_impala.py
+++ b/test/frame/algorithms/test_impala.py
@@ -370,8 +370,8 @@ class TestIMPALA(object):
         env = c.env
         world = get_world()
         all_group = world.create_rpc_group("all", ["0", "1", "2"])
-        all_group.pair("{}_running".format(rank), True)
-        default_logger.info("{}, pid {}".format(rank, os.getpid()))
+        all_group.pair(f"{rank}_running", True)
+        default_logger.info(f"{rank}, pid {os.getpid()}")
         if rank == 0:
             all_group.pair("episode", episode)
 
@@ -424,7 +424,7 @@ class TestIMPALA(object):
                     if reward_fulfilled >= c.solved_repeat:
                         default_logger.info("Environment solved!")
 
-                        all_group.unpair("{}_running".format(rank))
+                        all_group.unpair(f"{rank}_running")
                         while all_group.is_paired("0_running") or all_group.is_paired(
                             "1_running"
                         ):

--- a/test/frame/algorithms/test_maddpg.py
+++ b/test/frame/algorithms/test_maddpg.py
@@ -577,13 +577,11 @@ class TestMADDPG(object):
             # "Agents are rewarded based on minimum agent distance
             #  to each landmark, penalized for collisions"
             smoother.update(total_reward / step.get())
-            logger.info("Episode {} total steps={}".format(episode, step))
+            logger.info(f"Episode {episode} total steps={step}")
             step.reset()
             terminal = False
 
-            logger.info(
-                "Episode {} total reward={:.2f}".format(episode, smoother.value)
-            )
+            logger.info(f"Episode {episode} total reward={smoother.value:.2f}")
 
             if smoother.value > c.solved_reward and episode > 20:
                 reward_fulfilled.count()

--- a/test/frame/algorithms/test_maddpg.py
+++ b/test/frame/algorithms/test_maddpg.py
@@ -20,7 +20,7 @@ from test.util_fixtures import *
 
 class Actor(nn.Module):
     def __init__(self, state_dim, action_dim, action_range):
-        super(Actor, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -36,7 +36,7 @@ class Actor(nn.Module):
 
 class ActorDiscrete(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(ActorDiscrete, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -56,7 +56,7 @@ class Critic(nn.Module):
         # Note: For MADDPG
         #       state_dim is the dimension of all states from all agents.
         #       action_dim is the dimension of all actions from all agents.
-        super(Critic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim + action_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -70,7 +70,7 @@ class Critic(nn.Module):
         return q
 
 
-class TestMADDPG(object):
+class TestMADDPG:
     # configs and definitions
     @pytest.fixture(scope="class")
     def train_config(self):

--- a/test/frame/algorithms/test_ppo.py
+++ b/test/frame/algorithms/test_ppo.py
@@ -277,9 +277,7 @@ class TestPPO(object):
             step.reset()
             terminal = False
 
-            logger.info(
-                "Episode {} total reward={:.2f}".format(episode, smoother.value)
-            )
+            logger.info(f"Episode {episode} total reward={smoother.value:.2f}")
 
             if smoother.value > c.solved_reward:
                 reward_fulfilled.count()

--- a/test/frame/algorithms/test_ppo.py
+++ b/test/frame/algorithms/test_ppo.py
@@ -17,7 +17,7 @@ from test.util_fixtures import *
 
 class Actor(nn.Module):
     def __init__(self, state_dim, action_num):
-        super(Actor, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -36,7 +36,7 @@ class Actor(nn.Module):
 
 class Critic(nn.Module):
     def __init__(self, state_dim):
-        super(Critic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 32)
         self.fc2 = nn.Linear(32, 32)
@@ -49,7 +49,7 @@ class Critic(nn.Module):
         return v
 
 
-class TestPPO(object):
+class TestPPO:
     # configs and definitions
     @pytest.fixture(scope="class")
     def train_config(self):

--- a/test/frame/algorithms/test_rainbow.py
+++ b/test/frame/algorithms/test_rainbow.py
@@ -302,9 +302,7 @@ class TestRAINBOW(object):
             step.reset()
             terminal = False
 
-            logger.info(
-                "Episode {} total reward={:.2f}".format(episode, smoother.value)
-            )
+            logger.info(f"Episode {episode} total reward={smoother.value:.2f}")
 
             if smoother.value > c.solved_reward:
                 reward_fulfilled.count()

--- a/test/frame/algorithms/test_rainbow.py
+++ b/test/frame/algorithms/test_rainbow.py
@@ -17,7 +17,7 @@ from test.util_fixtures import *
 class QNet(nn.Module):
     # this test setup lacks the noisy linear layer and dueling structure.
     def __init__(self, state_dim, action_num, atom_num=10):
-        super(QNet, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -31,7 +31,7 @@ class QNet(nn.Module):
         return t.softmax(self.fc3(a).view(-1, self.action_num, self.atom_num), dim=-1)
 
 
-class TestRAINBOW(object):
+class TestRAINBOW:
     # configs and definitions
     @pytest.fixture(scope="class")
     def train_config(self):

--- a/test/frame/algorithms/test_sac.py
+++ b/test/frame/algorithms/test_sac.py
@@ -24,7 +24,7 @@ def atanh(x):
 
 class Actor(nn.Module):
     def __init__(self, state_dim, action_dim, action_range):
-        super(Actor, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -74,7 +74,7 @@ class Actor(nn.Module):
 
 class Critic(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(Critic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim + action_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -88,7 +88,7 @@ class Critic(nn.Module):
         return q
 
 
-class TestSAC(object):
+class TestSAC:
     # configs and definitions
     @pytest.fixture(scope="class")
     def train_config(self):

--- a/test/frame/algorithms/test_sac.py
+++ b/test/frame/algorithms/test_sac.py
@@ -441,17 +441,13 @@ class TestSAC(object):
             if episode > 100:
                 for i in range(step.get()):
                     sac_train.update()
-                logger.info(
-                    "new entropy alpha: {}".format(sac_train.entropy_alpha.item())
-                )
+                logger.info(f"new entropy alpha: {sac_train.entropy_alpha.item()}")
 
             smoother.update(total_reward)
             step.reset()
             terminal = False
 
-            logger.info(
-                "Episode {} total reward={:.2f}".format(episode, smoother.value)
-            )
+            logger.info(f"Episode {episode} total reward={smoother.value:.2f}")
 
             if smoother.value > c.solved_reward:
                 reward_fulfilled.count()

--- a/test/frame/algorithms/test_td3.py
+++ b/test/frame/algorithms/test_td3.py
@@ -18,7 +18,7 @@ from test.util_fixtures import *
 
 class Actor(nn.Module):
     def __init__(self, state_dim, action_dim, action_range):
-        super(Actor, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -34,7 +34,7 @@ class Actor(nn.Module):
 
 class ActorDiscrete(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(ActorDiscrete, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -49,7 +49,7 @@ class ActorDiscrete(nn.Module):
 
 class Critic(nn.Module):
     def __init__(self, state_dim, action_dim):
-        super(Critic, self).__init__()
+        super().__init__()
 
         self.fc1 = nn.Linear(state_dim + action_dim, 16)
         self.fc2 = nn.Linear(16, 16)
@@ -63,7 +63,7 @@ class Critic(nn.Module):
         return q
 
 
-class TestTD3(object):
+class TestTD3:
     # configs and definitions
     @pytest.fixture(scope="class")
     def train_config(self):

--- a/test/frame/algorithms/test_td3.py
+++ b/test/frame/algorithms/test_td3.py
@@ -430,9 +430,7 @@ class TestTD3(object):
 
             if episode.get() % c.noise_interval != 0:
                 # only log result without noise
-                logger.info(
-                    "Episode {} total reward={:.2f}".format(episode, smoother.value)
-                )
+                logger.info(f"Episode {episode} total reward={smoother.value:.2f}")
 
             if smoother.value > c.solved_reward:
                 reward_fulfilled.count()

--- a/test/frame/algorithms/utils.py
+++ b/test/frame/algorithms/utils.py
@@ -9,7 +9,7 @@ def unwrap_time_limit(env):
         return env
 
 
-class Smooth(object):
+class Smooth:
     def __init__(self):
         self._value = None
 

--- a/test/frame/buffers/test_buffer.py
+++ b/test/frame/buffers/test_buffer.py
@@ -6,7 +6,7 @@ import pytest
 import torch as t
 
 
-class TestBuffer(object):
+class TestBuffer:
     BUFFER_SIZE = 1
     SAMPLE_BUFFER_SIZE = 10
 

--- a/test/frame/buffers/test_prioritized_buffer.py
+++ b/test/frame/buffers/test_prioritized_buffer.py
@@ -5,7 +5,7 @@ import numpy as np
 import torch as t
 
 
-class TestWeightTree(object):
+class TestWeightTree:
     WEIGHT_TREE_SIZE = 5
     WEIGHT_TREE_BASE = [1, 1, 1, 1, 3]
     WEIGHT_TREE_WEIGHTS = [1, 1, 1, 1, 3, 0, 0, 0, 2, 2, 3, 0, 4, 3, 7]
@@ -153,7 +153,7 @@ class TestWeightTree(object):
         sys.stdout = sys.__stdout__
 
 
-class TestPrioritizedBuffer(object):
+class TestPrioritizedBuffer:
     ########################################################################
     # Test for PrioritizedBuffer.append
     ########################################################################

--- a/test/frame/buffers/test_prioritized_buffer_d.py
+++ b/test/frame/buffers/test_prioritized_buffer_d.py
@@ -79,7 +79,7 @@ class TestDistributedPrioritizedBuffer(WorldTestBase):
     def test_append_sample_random(rank, trans_list):
         world = get_world()
         count = 0
-        default_logger.info("{} started".format(rank))
+        default_logger.info(f"{rank} started")
         group = world.create_rpc_group("group", ["0", "1", "2"])
         buffer = DistributedPrioritizedBuffer("buffer", group, 5)
         if rank in (0, 1):
@@ -87,7 +87,7 @@ class TestDistributedPrioritizedBuffer(WorldTestBase):
             while time() - begin < 10:
                 trans, prior = random.choice(trans_list)
                 buffer.append(trans)
-                default_logger.info("{} append {} success".format(rank, count))
+                default_logger.info(f"{rank} append {count} success")
                 count += 1
                 sleep(random.random() * 0.5)
         else:
@@ -95,7 +95,7 @@ class TestDistributedPrioritizedBuffer(WorldTestBase):
             begin = time()
             while time() - begin < 5:
                 batch_size, sample, indexes, priorities = buffer.sample_batch(10)
-                default_logger.info("sampled batch size: {}".format(batch_size))
+                default_logger.info(f"sampled batch size: {batch_size}")
                 assert batch_size > 0
                 # state
                 assert list(sample[0]["state_1"].shape) == [batch_size, 2]
@@ -112,7 +112,7 @@ class TestDistributedPrioritizedBuffer(WorldTestBase):
                 # simulate perform a backward process
                 sleep(1)
                 buffer.update_priority(priorities, indexes)
-                default_logger.info("{} sample {} success".format(rank, count))
+                default_logger.info(f"{rank} sample {count} success")
                 count += 1
                 sleep(1)
         return True
@@ -125,7 +125,7 @@ class TestDistributedPrioritizedBuffer(WorldTestBase):
     @WorldTestBase.setup_world
     def test_append_sample_controlled(rank, trans_list):
         world = get_world()
-        default_logger.info("{} started".format(rank))
+        default_logger.info(f"{rank} started")
         np.random.seed(0)
         group = world.create_rpc_group("group", ["0", "1", "2"])
         buffer = DistributedPrioritizedBuffer("buffer", group, 5)
@@ -139,7 +139,7 @@ class TestDistributedPrioritizedBuffer(WorldTestBase):
             batch_size, sample, indexes, priorities = buffer.sample_batch(
                 10, sample_attrs=["index"]
             )
-            default_logger.info("sampled batch size: {}".format(batch_size))
+            default_logger.info(f"sampled batch size: {batch_size}")
             default_logger.info(sample)
             default_logger.info(indexes)
             default_logger.info(priorities)
@@ -173,7 +173,7 @@ class TestDistributedPrioritizedBuffer(WorldTestBase):
     @WorldTestBase.setup_world
     def test_sample_empty_buffer(rank):
         world = get_world()
-        default_logger.info("{} started".format(rank))
+        default_logger.info(f"{rank} started")
         np.random.seed(0)
         group = world.create_rpc_group("group", ["0", "1", "2"])
         buffer = DistributedPrioritizedBuffer("buffer", group, 5)
@@ -195,7 +195,7 @@ class TestDistributedPrioritizedBuffer(WorldTestBase):
     @WorldTestBase.setup_world
     def test_append_sample_empty(rank, trans_list):
         world = get_world()
-        default_logger.info("{} started".format(rank))
+        default_logger.info(f"{rank} started")
         np.random.seed(0)
         group = world.create_rpc_group("group", ["0", "1", "2"])
         buffer = DistributedPrioritizedBuffer("buffer", group, 5)
@@ -221,7 +221,7 @@ class TestDistributedPrioritizedBuffer(WorldTestBase):
     @WorldTestBase.setup_world
     def test_append_size(rank, trans_list):
         world = get_world()
-        default_logger.info("{} started".format(rank))
+        default_logger.info(f"{rank} started")
         np.random.seed(0)
         group = world.create_rpc_group("group", ["0", "1", "2"])
         buffer = DistributedPrioritizedBuffer("buffer", group, 5)
@@ -248,7 +248,7 @@ class TestDistributedPrioritizedBuffer(WorldTestBase):
     @WorldTestBase.setup_world
     def test_append_clear(rank, trans_list):
         world = get_world()
-        default_logger.info("{} started".format(rank))
+        default_logger.info(f"{rank} started")
         np.random.seed(0)
         group = world.create_rpc_group("group", ["0", "1", "2"])
         buffer = DistributedPrioritizedBuffer("buffer", group, 5)

--- a/test/frame/noise/test_action_space_noise.py
+++ b/test/frame/noise/test_action_space_noise.py
@@ -9,7 +9,7 @@ import pytest
 import torch as t
 
 
-class TestAllActionSpaceNoise(object):
+class TestAllActionSpaceNoise:
     ########################################################################
     # Test for add_normal_noise_to_action
     ########################################################################

--- a/test/frame/noise/test_generator.py
+++ b/test/frame/noise/test_generator.py
@@ -8,7 +8,7 @@ from machin.frame.noise.generator import (
 import torch as t
 
 
-class TestAllNoiseGen(object):
+class TestAllNoiseGen:
     ########################################################################
     # Test for all noise generators
     ########################################################################

--- a/test/frame/noise/test_param_space_noise.py
+++ b/test/frame/noise/test_param_space_noise.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 ############################################################################
 # Test for AdaptiveParamNoise
 ############################################################################
-class TestAdaptiveParamNoise(object):
+class TestAdaptiveParamNoise:
     def test_adapt(self):
         spec = AdaptiveParamNoise()
         spec.adapt(1.0)

--- a/test/frame/test_transition.py
+++ b/test/frame/test_transition.py
@@ -4,7 +4,7 @@ import pytest
 import torch as t
 
 
-class TestTransitionBase(object):
+class TestTransitionBase:
     ########################################################################
     # Test for TransitionBase.__init__
     ########################################################################
@@ -235,7 +235,7 @@ class TestTransitionBase(object):
         tb.to(pytestconfig.getoption("gpu_device"))
 
 
-class TestTransition(object):
+class TestTransition:
     ########################################################################
     # Test for Transition.__init__
     ########################################################################

--- a/test/parallel/distributed/test_world.py
+++ b/test/parallel/distributed/test_world.py
@@ -4,7 +4,7 @@ from test.util_fixtures import *
 import torch as t
 
 
-class WorkerService(object):
+class WorkerService:
     counter = 0
 
     def count(self):

--- a/test/parallel/server/test_ordered_server.py
+++ b/test/parallel/server/test_ordered_server.py
@@ -3,7 +3,7 @@ from test.util_run_multi import *
 
 
 def _log(rank, msg):
-    default_logger.info("Client {}: {}".format(rank, msg))
+    default_logger.info(f"Client {rank}: {msg}")
 
 
 class Object(object):

--- a/test/parallel/server/test_ordered_server.py
+++ b/test/parallel/server/test_ordered_server.py
@@ -6,7 +6,7 @@ def _log(rank, msg):
     default_logger.info(f"Client {rank}: {msg}")
 
 
-class Object(object):
+class Object:
     pass
 
 

--- a/test/parallel/server/test_param_server.py
+++ b/test/parallel/server/test_param_server.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 
 
 def _log(rank, msg):
-    default_logger.info("Client {}: {}".format(rank, msg))
+    default_logger.info(f"Client {rank}: {msg}")
 
 
 class Model(nn.Module):
@@ -72,9 +72,9 @@ class TestPushPullModelServer(WorldTestBase):
                     model.fc2.weight += 1
                     model.fc3.weight += 1
                 if server.push(model):
-                    _log(rank, "push {} success".format(i))
+                    _log(rank, f"push {i} success")
                 else:
-                    _log(rank, "push {} failed".format(i))
+                    _log(rank, f"push {i} failed")
                 model.pp_version = i + 1
                 _log(
                     rank,
@@ -138,11 +138,11 @@ class TestPushPullGradServer(WorldTestBase):
                 loss = model(t.ones([1, 1]))
                 loss.backward()
                 server.push(model)
-                _log(rank, "iter {}, model: {}".format(i, model))
+                _log(rank, f"iter {i}, model: {model}")
                 sleep(random.random() * 0.2)
             sleep(3)
             server.pull(model)
-            _log(rank, "reduced model: {}".format(model))
+            _log(rank, f"reduced model: {model}")
             # reduce_method = "mean":
             # fc1: weight(1) - 6 = -5
             # fc2: weight(2) - 3 = -1

--- a/test/parallel/server/test_param_server.py
+++ b/test/parallel/server/test_param_server.py
@@ -11,7 +11,7 @@ def _log(rank, msg):
 
 class Model(nn.Module):
     def __init__(self):
-        super(Model, self).__init__()
+        super().__init__()
         self.fc1 = nn.Linear(1, 1, bias=False)
         self.fc2 = nn.Linear(1, 1, bias=False)
         self.fc3 = nn.Linear(1, 1, bias=False)
@@ -35,7 +35,7 @@ class Model(nn.Module):
         )
 
 
-class Optimizer(object):
+class Optimizer:
     def __init__(self, param):
         self.params = param
 

--- a/test/parallel/test_assigner.py
+++ b/test/parallel/test_assigner.py
@@ -1,13 +1,13 @@
 from machin.parallel.assigner import ModelSizeEstimator, ModelAssigner
 from machin.utils.helper_classes import Object
 
-import mock
+from unittest import mock
 import pytest
 import torch as t
 import torch.nn as nn
 
 
-class TestModelSizeEstimator(object):
+class TestModelSizeEstimator:
     def test_estimator(self):
         model = nn.Module()
         model.register_parameter(
@@ -34,7 +34,7 @@ class TestModelSizeEstimator(object):
         ) / (1024 ** 2)
 
 
-class TestModelAssigner(object):
+class TestModelAssigner:
     # unit of size is MB
     virtual_gpus = []
     virtual_cpu = 0

--- a/test/parallel/test_pool.py
+++ b/test/parallel/test_pool.py
@@ -22,7 +22,7 @@ def func2(x, y):
     return t.sum(x + y)
 
 
-class TestPool(object):
+class TestPool:
     pool_impl = Pool
 
     def test_apply(self):
@@ -198,7 +198,7 @@ def ctx_func2(ctx, x, y):
     return ctx, x + y
 
 
-class TestCtxPool(object):
+class TestCtxPool:
     def test_init(self):
         with pytest.raises(ValueError, match="not equal to the number"):
             _ = CtxPool(processes=2, worker_contexts=[0, 1, 2, 3])
@@ -215,7 +215,7 @@ class TestCtxPool(object):
         x = [i for i in range(10)]
         result = pool.map(ctx_func, x)
         assert sorted([r[1] for r in result]) == x
-        assert set([r[0] for r in result]).issubset({0, 1})
+        assert {r[0] for r in result}.issubset({0, 1})
         pool.close()
         pool.join()
 
@@ -225,7 +225,7 @@ class TestCtxPool(object):
         xy = [(i, i) for i in range(10)]
         result = pool.starmap(ctx_func2, xy)
         assert sorted([r[1] for r in result]) == [i * 2 for i in range(10)]
-        assert set([r[0] for r in result]).issubset({0, 1})
+        assert {r[0] for r in result}.issubset({0, 1})
         pool.close()
         pool.join()
 
@@ -239,16 +239,16 @@ class TestCtxPool(object):
         result = pool.map(ctx_func, x)
         result2 = pool2.map(ctx_func, x)
         assert sorted([r[1] for r in result]) == x
-        assert set([r[0] for r in result]).issubset({0, 1})
+        assert {r[0] for r in result}.issubset({0, 1})
         assert sorted([r[1] for r in result2]) == x
-        assert set([r[0] for r in result2]).issubset({2, 3})
+        assert {r[0] for r in result2}.issubset({2, 3})
         pool.close()
         pool.join()
         pool2.close()
         pool2.join()
 
 
-class TestThreadPool(object):
+class TestThreadPool:
     def test_size(self):
         pool = ThreadPool(processes=2)
         assert pool.size() == 2
@@ -260,7 +260,7 @@ class TestThreadPool(object):
             dill.dumps(ThreadPool(processes=2))
 
 
-class TestCtxThreadPool(object):
+class TestCtxThreadPool:
     def test_init(self):
         with pytest.raises(ValueError, match="not equal to the number"):
             _ = CtxThreadPool(processes=2, worker_contexts=[0, 1, 2, 3])
@@ -291,7 +291,7 @@ class TestCtxThreadPool(object):
         x = [i for i in range(10)]
         result = pool.map(ctx_func, x)
         assert sorted([r[1] for r in result]) == x
-        assert set([r[0] for r in result]).issubset({0, 1})
+        assert {r[0] for r in result}.issubset({0, 1})
         pool.close()
         pool.join()
 
@@ -300,7 +300,7 @@ class TestCtxThreadPool(object):
         x = [i for i in range(10)]
         result = pool.map_async(ctx_func, x).get()
         assert sorted([r[1] for r in result]) == x
-        assert set([r[0] for r in result]).issubset({0, 1})
+        assert {r[0] for r in result}.issubset({0, 1})
         pool.close()
         pool.join()
 
@@ -309,7 +309,7 @@ class TestCtxThreadPool(object):
         x = [i for i in range(10)]
         result = pool.imap(ctx_func, x)
         assert sorted([r[1] for r in result]) == x
-        assert set([r[0] for r in result]).issubset({0, 1})
+        assert {r[0] for r in result}.issubset({0, 1})
         pool.close()
         pool.join()
 
@@ -318,7 +318,7 @@ class TestCtxThreadPool(object):
         x = [i for i in range(10)]
         result = pool.imap_unordered(ctx_func, x)
         assert sorted([r[1] for r in result]) == x
-        assert set([r[0] for r in result]).issubset({0, 1})
+        assert {r[0] for r in result}.issubset({0, 1})
         pool.close()
         pool.join()
 
@@ -327,7 +327,7 @@ class TestCtxThreadPool(object):
         xy = [(i, i) for i in range(10)]
         result = pool.starmap(ctx_func2, xy)
         assert sorted([r[1] for r in result]) == [i * 2 for i in range(10)]
-        assert set([r[0] for r in result]).issubset({0, 1})
+        assert {r[0] for r in result}.issubset({0, 1})
         pool.close()
         pool.join()
 
@@ -336,7 +336,7 @@ class TestCtxThreadPool(object):
         xy = [(i, i) for i in range(10)]
         result = pool.starmap_async(ctx_func2, xy).get()
         assert sorted([r[1] for r in result]) == [i * 2 for i in range(10)]
-        assert set([r[0] for r in result]).issubset({0, 1})
+        assert {r[0] for r in result}.issubset({0, 1})
         pool.close()
         pool.join()
 
@@ -350,9 +350,9 @@ class TestCtxThreadPool(object):
         result = pool.map(ctx_func, x)
         result2 = pool2.map(ctx_func, x)
         assert sorted([r[1] for r in result]) == x
-        assert set([r[0] for r in result]).issubset({0, 1})
+        assert {r[0] for r in result}.issubset({0, 1})
         assert sorted([r[1] for r in result2]) == x
-        assert set([r[0] for r in result2]).issubset({2, 3})
+        assert {r[0] for r in result2}.issubset({2, 3})
         pool.close()
         pool.join()
         pool2.close()

--- a/test/util_run_multi.py
+++ b/test/util_run_multi.py
@@ -59,7 +59,7 @@ def processes():
     default_logger.addHandler(handler)
 
     for p, i in zip(processes, [0, 1, 2]):
-        default_logger.info("processes {} started".format(i))
+        default_logger.info(f"processes {i} started")
         p.start()
     yield processes, [pi[1] for pi in pipes]
     for p, pi, i in zip(processes, pipes, [0, 1, 2]):
@@ -68,7 +68,7 @@ def processes():
         p.join(timeout=1)
         if p.is_alive():
             # ungraceful shutdown
-            default_logger.info("processes {} ungraceful shutdown".format(i))
+            default_logger.info(f"processes {i} ungraceful shutdown")
             p.terminate()
             p.join()
     default_logger.removeHandler(handler)
@@ -135,14 +135,12 @@ def run_multi(
 
     def deco(func):
         return FunctionMaker.create(
-            "w_wrapped_func(processes{})".format(pt_args),
-            """
+            f"w_wrapped_func(processes{pt_args})",
+            f"""
             return exec_with_process(
                 processes, func, args_list, kwargs_list, 
-                expected_results, timeout{})
-            """.format(
-                pt_args
-            ),
+                expected_results, timeout{pt_args})
+            """,
             dict(
                 args_list=args_list,
                 kwargs_list=kwargs_list,
@@ -162,12 +160,12 @@ class WorldTestBase(object):
         def wrapped(rank, *args, _world_port=9100, **kwargs):
             # election function for all tests
             world = World(world_size=3, rank=rank, name=str(rank))
-            default_logger.info("World using port {}".format(_world_port))
+            default_logger.info(f"World using port {_world_port}")
             # set a temporary success attribute on world
-            default_logger.info("World created on {}".format(rank))
+            default_logger.info(f"World created on {rank}")
             result = func(rank, *args, **kwargs)
             world.stop()
-            default_logger.info("World stopped on {}".format(rank))
+            default_logger.info(f"World stopped on {rank}")
             return result
 
         return wrapped

--- a/test/util_run_multi.py
+++ b/test/util_run_multi.py
@@ -154,7 +154,7 @@ def run_multi(
     return deco
 
 
-class WorldTestBase(object):
+class WorldTestBase:
     @staticmethod
     def setup_world(func):
         def wrapped(rank, *args, _world_port=9100, **kwargs):

--- a/test/utils/test_checker.py
+++ b/test/utils/test_checker.py
@@ -28,7 +28,7 @@ def test_check_nan():
 
 class SubModule1(nn.Module):
     def __init__(self):
-        super(SubModule1, self).__init__()
+        super().__init__()
         self.fc1 = nn.Linear(5, 10)
         self.fc2 = nn.Linear(10, 20)
         mark_as_atom_module(self)
@@ -40,7 +40,7 @@ class SubModule1(nn.Module):
 
 class SubModule2(nn.Module):
     def __init__(self):
-        super(SubModule2, self).__init__()
+        super().__init__()
         self.fc1 = nn.Linear(20, 20)
 
     def forward(self, x):
@@ -49,7 +49,7 @@ class SubModule2(nn.Module):
 
 class CheckedModel(nn.Module):
     def __init__(self):
-        super(CheckedModel, self).__init__()
+        super().__init__()
         self.sub1 = SubModule1()
         self.sub2 = SubModule2()
 

--- a/test/utils/test_conf.py
+++ b/test/utils/test_conf.py
@@ -9,7 +9,7 @@ from machin.utils.helper_classes import Object
 from os.path import join
 import os
 import json
-import mock
+from unittest import mock
 
 
 def get_config():

--- a/test/utils/test_helper_classes.py
+++ b/test/utils/test_helper_classes.py
@@ -2,7 +2,7 @@ from machin.utils.helper_classes import Counter, Trigger, Timer, Switch, Object
 import pytest
 
 
-class TestCounter(object):
+class TestCounter:
     def test_counter(self):
         c = Counter(start=0, step=1)
         c.count()
@@ -17,7 +17,7 @@ class TestCounter(object):
         str(c)
 
 
-class TestSwitch(object):
+class TestSwitch:
     def test_switch(self):
         s = Switch()
         s.on()
@@ -28,7 +28,7 @@ class TestSwitch(object):
         assert s.get()
 
 
-class TestTrigger(object):
+class TestTrigger:
     def test_trigger(self):
         t = Trigger()
         t.on()
@@ -36,14 +36,14 @@ class TestTrigger(object):
         assert not t.get()
 
 
-class TestTimer(object):
+class TestTimer:
     def test_timer(self):
         t = Timer()
         t.begin()
         t.end()
 
 
-class TestObject(object):
+class TestObject:
     def test_init(self):
         obj = Object()
         assert obj.data == {}

--- a/test/utils/test_tensor_board.py
+++ b/test/utils/test_tensor_board.py
@@ -2,7 +2,7 @@ from machin.utils.tensor_board import default_board
 import pytest
 
 
-class TestTensorBoard(object):
+class TestTensorBoard:
     def test_tensor_board(self):
         default_board.init()
         with pytest.raises(RuntimeError, match="has been initialized"):

--- a/test/utils/test_visualize.py
+++ b/test/utils/test_visualize.py
@@ -1,5 +1,5 @@
 from machin.utils.visualize import visualize_graph
-import mock
+from unittest import mock
 import torch as t
 
 


### PR DESCRIPTION
Hey,

Since python 3.5 was deprecated, now it's possible to upgrade the code to use f-strings and more modern class notation.

Used following tools to derive this change:
* flynt v.0.63
* pyupgrade v.2.11.0

Will follow-up with .git-ignore-revs.